### PR TITLE
Add 'crossOrigin' attribute to SVG image element.

### DIFF
--- a/src/tools/Tools.mjs
+++ b/src/tools/Tools.mjs
@@ -173,6 +173,7 @@ export default class Tools {
         img.onError = (err) => {
             cb(err);
         }
+        img.crossOrigin = "Anonymous";
         img.src = url;
     }
 


### PR DESCRIPTION
This is to prevent the following error when trying to load SVG images from foreign origins (that provide proper CORS headers):
```
Uncaught DOMException: Failed to execute 'texImage2D' on 'WebGLRenderingContext': Tainted canvases may not be loaded.
```