### PR TITLE
Fixed text line height centering.

### DIFF
--- a/src/textures/TextTextureRenderer.mjs
+++ b/src/textures/TextTextureRenderer.mjs
@@ -271,7 +271,7 @@ export default class TextTextureRenderer {
         // Draw lines line by line.
         for (let i = 0, n = lines.length; i < n; i++) {
             linePositionX = 0;
-            linePositionY = (i * lineHeight) + offsetY;
+            linePositionY = (i * lineHeight) + offsetY + (lineHeight - fontSize) / 2;
 
             if (this._settings.textAlign === 'right') {
                 linePositionX += (innerWidth - lineWidths[i]);

--- a/src/textures/TextTextureRenderer.mjs
+++ b/src/textures/TextTextureRenderer.mjs
@@ -293,7 +293,7 @@ export default class TextTextureRenderer {
         // Draw lines line by line.
         for (let i = 0, n = renderInfo.lines.length; i < n; i++) {
             linePositionX = 0;
-            linePositionY = (i * lineHeight) + offsetY + (lineHeight - fontSize) / 2;
+            linePositionY = (i * renderInfo.lineHeight) + renderInfo.offsetY + (renderInfo.lineHeight - renderInfo.fontSize) / 2;
 
             if (this._settings.textAlign === 'right') {
                 linePositionX += (renderInfo.innerWidth - renderInfo.lineWidths[i]);


### PR DESCRIPTION
When line height is larger than font size, text should be positioned in the center rather than on the top.

Resolves #164 