### PR TITLE
Add guard in TextureSource#_isNativeTexture for platforms that don't have WebGL support

### DIFF
--- a/src/tree/TextureSource.mjs
+++ b/src/tree/TextureSource.mjs
@@ -374,7 +374,15 @@ export default class TextureSource {
     }
 
     _isNativeTexture(source) {
-        return ((Utils.isNode ? source.constructor.name === "WebGLTexture" : source instanceof WebGLTexture));
+        if (Utils.isNode) {
+            return source.constructor.name === "WebGLTexture";
+        }
+
+        if ('WebGLTexture' in window) {
+            return source instanceof WebGLTexture;
+        }
+
+        return false;
     }
 
 }


### PR DESCRIPTION
Fixes #16

The PS4 (and potentially other platforms) do not support WebGL and therefore `WebGLTexture` is undefined on the global `window` object.

RDK CLA has been signed.