### PR TITLE
Added support for base64 images.

### DIFF
--- a/src/platforms/browser/ImageWorker.mjs
+++ b/src/platforms/browser/ImageWorker.mjs
@@ -144,7 +144,7 @@ const createWorker = function() {
     }
 
     ImageWorkerServer.isPathAbsolute = function(path) {
-        return /^(?:\/|[a-z]+:\/\/)/.test(path);
+        return /^(?:\/|[a-z]+:\/\/)/.test(path) || path.substr(0, 5) == 'data:';
     };
 
     ImageWorkerServer.prototype._receiveMessage = function(e) {

--- a/src/platforms/browser/WebPlatform.mjs
+++ b/src/platforms/browser/WebPlatform.mjs
@@ -81,7 +81,7 @@ export default class WebPlatform {
 
     loadSrcTexture({src, hasAlpha}, cb) {
         let cancelCb = undefined;
-        let isPng = (src.indexOf(".png") >= 0);
+        let isPng = (src.indexOf(".png") >= 0) || src.substr(0, 21) == 'data:image/png;base64';
         if (this._imageWorker) {
             // WPE-specific image parser.
             const image = this._imageWorker.create(src);


### PR DESCRIPTION
Allows to use base64 encoded string as image source, e.g.

```javascript
Img : {
  src: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA...',
  w: 200,
  h: 200
}
```