### PR TITLE
Add option for setting crossOrigin attribute on images (#226)

### DIFF
--- a/src/platforms/browser/WebPlatform.mjs
+++ b/src/platforms/browser/WebPlatform.mjs
@@ -100,8 +100,9 @@ export default class WebPlatform {
                 image.cancel();
             }
         } else {
+            const setAnonymousCrossOrigin = this.stage.getOption('setAnonymousCrossOrigin');
             let image = new Image();
-            if (!(src.substr(0,5) == "data:")) {
+            if (setAnonymousCrossOrigin && !(src.substr(0,5) == "data:")) {
                 // Base64.
                 image.crossOrigin = "Anonymous";
             }

--- a/src/tools/Tools.mjs
+++ b/src/tools/Tools.mjs
@@ -161,6 +161,7 @@ export default class Tools {
     static createSvg(cb, stage, url, w, h) {
         let canvas = stage.platform.getDrawingCanvas();
         let ctx = canvas.getContext('2d');
+        const setAnonymousCrossOrigin = this.stage.getOption('setAnonymousCrossOrigin');
         ctx.imageSmoothingEnabled = true;
 
         let img = new Image();
@@ -173,7 +174,11 @@ export default class Tools {
         img.onError = (err) => {
             cb(err);
         }
-        img.crossOrigin = "Anonymous";
+
+        if (setAnonymousCrossOrigin) {
+            img.crossOrigin = "Anonymous";
+        }
+
         img.src = url;
     }
 

--- a/src/tree/Stage.mjs
+++ b/src/tree/Stage.mjs
@@ -186,6 +186,7 @@ export default class Stage extends EventEmitter {
         opt('canvas2d', false);
         opt('platform', null);
         opt('readPixelsBeforeDraw', false);
+        opt('setAnonymousCrossOrigin', true);
     }
 
     setApplication(app) {


### PR DESCRIPTION
This PR adds a stage option to Lightning for setting the `crossOrigin: "Anonymous"` attribute on images. This allows problematic platforms to disable the attribute and avoid CORS issues.