### PR TITLE
Don't set crossOrigin attribute on images on PS4 platform (#226)

### DIFF
--- a/src/platforms/browser/WebPlatform.mjs
+++ b/src/platforms/browser/WebPlatform.mjs
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 
+import Utils from "../../tree/Utils.mjs";
 import ImageWorker from "./ImageWorker.mjs";
 
 /**
@@ -101,7 +102,10 @@ export default class WebPlatform {
             }
         } else {
             let image = new Image();
-            if (!(src.substr(0,5) == "data:")) {
+
+            // On the PS4 platform setting the `crossOrigin` attribute on
+            // images can cause CORS failures.
+            if (!(src.substr(0,5) == "data:") && !Utils.isPS4) {
                 // Base64.
                 image.crossOrigin = "Anonymous";
             }

--- a/src/tools/Tools.mjs
+++ b/src/tools/Tools.mjs
@@ -173,7 +173,13 @@ export default class Tools {
         img.onError = (err) => {
             cb(err);
         }
-        img.crossOrigin = "Anonymous";
+
+        // On the PS4 platform setting the `crossOrigin` attribute on images
+        // can cause CORS failures.
+        if (!Utils.isPS4) {
+            img.crossOrigin = "Anonymous";
+        }
+
         img.src = url;
     }
 

--- a/src/tree/Utils.mjs
+++ b/src/tree/Utils.mjs
@@ -194,3 +194,4 @@ Utils.isWeb = (typeof window !== "undefined") && (typeof sparkscene === "undefin
 Utils.isWPE = Utils.isWeb && (navigator.userAgent.indexOf("WPE") !== -1);
 Utils.isSpark = (typeof sparkscene !== "undefined");
 Utils.isNode = (typeof window === "undefined") || Utils.isSpark;
+Utils.isPS4 = Utils.isWeb && (navigator.userAgent.indexOf("PlayStation 4") !== -1);


### PR DESCRIPTION
Followup to https://github.com/rdkcentral/Lightning/pull/227.

This PR adds a guard for the PS4 platform when adding the `crossOrigin` attribute to images, as it causes CORS errors.