### PR TITLE
Fix error when aggressively garbage collecting canvas2d textures (#246)

### DIFF
--- a/src/renderer/c2d/C2dTextureTintManager.mjs
+++ b/src/renderer/c2d/C2dTextureTintManager.mjs
@@ -125,7 +125,7 @@ export default class C2dTextureTintManager {
             const cache = this._getCache(texture);
             if (aggressive) {
                 delta += cache.memoryUsage;
-                texture.clear();
+                cache.clear();
             } else {
                 const before = cache.memoryUsage;
                 cache.cleanup(frame);


### PR DESCRIPTION
I believe we should be calling `clear()` on the tint cache instance rather than the texture directly.