### PR TITLE
Add an option to define "data-testid" attribute in inspect mode for functional/e2e testing

### DIFF
--- a/devtools/lightning-inspect.js
+++ b/devtools/lightning-inspect.js
@@ -661,6 +661,18 @@ window.attachInspector = function({Element, ElementCore, Stage, Component, Eleme
         }
     });
 
+    Element.prototype.$testId = null;
+    Object.defineProperty(Element.prototype, 'testId', {
+        get: function() {
+            return this.$testId;
+        },
+        set: function(v) {
+            if (this.$testId !== v) {
+                this.$testId = v;
+                val(this, 'data-testid', v, null);
+            }
+        }
+    });
 
     var checkColors = function(elementRenderer) {
         let element = elementRenderer._element;


### PR DESCRIPTION
`data-testid` is a common way to define unique identifier for usage with functional testing tools, such as Suitest, Cypress etc.

With this PR, users will be able to specify the id like so:
```
{
  rect: true,
  w: 200, h: 200, y: 10, x: 10,
  testId: 'login-button'
}
```

Then, in inspector it will be rendered as:
```
<div data-testid="login-button" ... />
```

There is a branch already created with similar functionality [feature/inspector-custom-id](https://github.com/rdkcentral/Lightning/tree/feature/inspector-custom-id), but there is no pull request open and it's already 6 month old. Plus, `data-testid` is arguably cleaner way to do it, as regular `id` might be used for something else in Lightning inspector.