### PR TITLE
Correctly identify the license of the package

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Metrological, Bas van Meurs <b.van.meurs@metrological.com>",
   "name": "@lightningjs/core",
   "version": "2.3.0",
-  "license": "apache",
+  "license": "Apache-2.0",
   "main": "dist/lightning.js",
   "module": "index.js",
   "files": [


### PR DESCRIPTION
Systems that scan license IDs expect standard license identifiers from [SPDX](https://spdx.org/licenses/). This also disambiguates between Apache-1.1 and Apache-2.0 and conforms with the [package.json documentation](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#license).