### PR TITLE
fix(lightning-inpect.js): fix texture-text

### DIFF
--- a/devtools/lightning-inspect.js
+++ b/devtools/lightning-inspect.js
@@ -797,7 +797,11 @@ window.attachInspector = function({Application, Element, ElementCore, Stage, Com
                         f += c
                     }
                 }
-                val(element, `texture-${f}`, nonDefaults[key], false);
+                if (nonDefaults[key].toString() === '0') {
+                    val(element, `texture-${f}`, nonDefaults[key], true);
+                } else {
+                    val(element, `texture-${f}`, nonDefaults[key], false);
+                }
             })
         }
     }


### PR DESCRIPTION
Bug fix issue https://github.com/rdkcentral/Lightning/issues/341

Fix remove the property texture-text if the text value is 0 because, if not the val function will remove the property from the object.