### PR TITLE
Inspector, update root div when canvas width update

### DIFF
--- a/devtools/lightning-inspect.js
+++ b/devtools/lightning-inspect.js
@@ -193,15 +193,26 @@ window.attachInspector = function({Application, Element, ElementCore, Stage, Com
             var root = document.createElement('DIV');
             document.body.appendChild(root);
             var self = this;
-            setTimeout(function() {
-                var bcr = self.stage.getCanvas().getBoundingClientRect();
+            let updateRootStyleFromCanvas = function (bcr) {
                 root.style.left = bcr.left + 'px';
                 root.style.top = bcr.top + 'px';
                 root.style.width = Math.ceil(bcr.width / self.stage.getRenderPrecision()) + 'px';
                 root.style.height = Math.ceil(bcr.height / self.stage.getRenderPrecision()) + 'px';
                 root.style.transformOrigin = '0 0 0';
                 root.style.transform = 'scale(' + self.stage.getRenderPrecision() + ',' + self.stage.getRenderPrecision() + ')';
-            }, 1000);
+            }
+
+            if (ResizeObserver != null) {
+                const resize_ob = new ResizeObserver(function (entries) {
+                    updateRootStyleFromCanvas(entries[0].contentRect);
+                });
+                // start observing for resize
+                resize_ob.observe(this.stage.getCanvas());
+            } else {
+                setTimeout(function () {
+                    updateRootStyleFromCanvas(self.stage.getCanvas().getBoundingClientRect());
+                }, 1000);
+            }
 
             root.style.position = 'absolute';
             root.style.overflow = 'hidden';


### PR DESCRIPTION
I observed that width and height of the root div for the inspector is retrieved based on a timeout of 1s when inspect scripts is loaded. If the width and / or height of the canvas is modified after this delay, the root div of inspector keep a width and height of 0. As a result, when using Chrome inspector, we do not see the overlay of inspected elements (ie blue rectangle).

Regards