### PR TITLE
Improve support for vertical alignment on advanced text renderer.

### DIFF
--- a/src/textures/TextTexture.mjs
+++ b/src/textures/TextTexture.mjs
@@ -81,6 +81,17 @@ export default class TextTexture extends Texture {
         }
     }
 
+    get fontBaselineRatio() {
+        return this._fontBaselineRatio;
+    }
+    
+    set fontBaselineRatio(v) {
+        if (this._fontBaselineRatio !== v) {
+            this._fontBaselineRatio = v
+            this._changed();
+        }
+    }
+
     get fontSize() {
         return this._fontSize;
     }
@@ -478,6 +489,7 @@ export default class TextTexture extends Texture {
         if (this.h !== 0) parts.push("h " + this.h);
         if (this.fontStyle !== "normal") parts.push("fS" + this.fontStyle);
         if (this.fontSize !== 40) parts.push("fs" + this.fontSize);
+        if (this.fontBaselineRatio !== 0) parts.push('fb' + this.fontBaselineRatio);
         if (this.fontFace !== null) parts.push("ff" + (Array.isArray(this.fontFace) ? this.fontFace.join(",") : this.fontFace));
         if (this.wordWrap !== true) parts.push("wr" + (this.wordWrap ? 1 : 0));
         if (this.wordWrapWidth !== 0) parts.push("ww" + this.wordWrapWidth);
@@ -583,6 +595,7 @@ export default class TextTexture extends Texture {
         if (this.h !== 0) nonDefaults['h'] = this.h;
         if (this.fontStyle !== "normal") nonDefaults['fontStyle'] = this.fontStyle;
         if (this.fontSize !== 40) nonDefaults["fontSize"] = this.fontSize;
+        if (this.fontBaselineRatio !== 0) nonDefaults['fontBaselineRatio'] = this.fontBaselineRatio;
         if (this.fontFace !== null) nonDefaults["fontFace"] = this.fontFace;
         if (this.wordWrap !== true) nonDefaults["wordWrap"] = this.wordWrap;
         if (this.wordWrapWidth !== 0) nonDefaults["wordWrapWidth"] = this.wordWrapWidth;
@@ -629,6 +642,7 @@ export default class TextTexture extends Texture {
         obj.h = this._h;
         obj.fontStyle = this._fontStyle;
         obj.fontSize = this._fontSize;
+        obj.fontBaselineRatio = this._fontBaselineRatio;
         obj.fontFace = this._fontFace;
         obj.wordWrap = this._wordWrap;
         obj.wordWrapWidth = this._wordWrapWidth;

--- a/src/textures/TextTexture.mjs
+++ b/src/textures/TextTexture.mjs
@@ -87,7 +87,7 @@ export default class TextTexture extends Texture {
     
     set fontBaselineRatio(v) {
         if (this._fontBaselineRatio !== v) {
-            this._fontBaselineRatio = v
+            this._fontBaselineRatio = v;
             this._changed();
         }
     }
@@ -724,6 +724,7 @@ proto._cutEx = 0;
 proto._cutSy = 0;
 proto._cutEy = 0;
 proto._advancedRenderer = false;
+proto._fontBaselineRatio = 0;
 
 
 import TextTextureRenderer from "./TextTextureRenderer.mjs";

--- a/src/textures/TextTextureRendererAdvanced.mjs
+++ b/src/textures/TextTextureRendererAdvanced.mjs
@@ -119,6 +119,8 @@ export default class TextTextureRendererAdvanced {
         renderInfo.text = this._settings.text;
         renderInfo.precision = precision;
         renderInfo.fontSize = fontSize;
+        // 0 is used as the baseline ratio if none is provided so it has no impact over the browser default rendering.
+        renderInfo.fontBaselineRatio = this._settings.fontBaselineRatio || 0.0 
         renderInfo.lineHeight = lineHeight;
         renderInfo.letterSpacing = letterSpacing;
         renderInfo.textAlign = this._settings.textAlign;
@@ -202,12 +204,36 @@ export default class TextTextureRendererAdvanced {
         }
         renderInfo.lineNum = lineNo + 1;
 
+        if (this._settings.h) {
+            renderInfo.h = this._settings.h;
+        } else if (renderInfo.maxLines && renderInfo.maxLines < renderInfo.lineNum) {
+            renderInfo.h = renderInfo.maxLines * renderInfo.lineHeight + fontSize / 2;
+        } else if (renderInfo.lineHeight > fontSize) {
+            // When lineheight is larger than the font size we're rendering, we set the height of the canvas based on the number of lines we're rendering.
+            // This makes each "line" a containing box that is line height sized, and text is positioned inside that box.
+            //
+            // Ideographic fonts may break this model, and require additional space?
+            renderInfo.h = renderInfo.lineNum * renderInfo.lineHeight
+        } else {
+            renderInfo.h = renderInfo.lineNum * renderInfo.lineHeight + fontSize / 2;
+        }
+
+        // This calculates the baseline offset in pixels from the font size.
+        // To retrieve this ratio, you would do this calculation:
+        //     (FontUnitsPerEm − hhea.Ascender − hhea.Descender) / (2 × FontUnitsPerEm)
+        //
+        // This give you the ratio for the baseline, which is then used to figure out 
+        // where the baseline is relative to the bottom of the text bounding box.
+        const baselineOffsetInPx = renderInfo.fontBaselineRatio * renderInfo.fontSize
+
         // Vertical align
         let vaOffset = 0;
-        if (renderInfo.verticalAlign == 'middle') {
-            vaOffset += (renderInfo.lineHeight - renderInfo.fontSize) / 2;
+        if (renderInfo.verticalAlign == 'top' && this._context.textBaseline == 'alphabetic') {
+            vaOffset = -baselineOffsetInPx;
+        } else if (renderInfo.verticalAlign == 'middle') {
+            vaOffset = (renderInfo.lineHeight - renderInfo.fontSize - baselineOffsetInPx) / 2;
         } else if (this._settings.verticalAlign == 'bottom') {
-            vaOffset += renderInfo.lineHeight - renderInfo.fontSize;
+            vaOffset = renderInfo.lineHeight - renderInfo.fontSize;
         }
 
         // Calculate lines information
@@ -280,14 +306,6 @@ export default class TextTextureRendererAdvanced {
 
             renderInfo.lines[index].text = lastLineText;
             renderInfo.lines[index].width = _w;
-        }
-
-        if (this._settings.h) {
-            renderInfo.h = this._settings.h;
-        } else if (renderInfo.maxLines && renderInfo.maxLines < renderInfo.lineNum) {
-            renderInfo.h = renderInfo.maxLines * renderInfo.lineHeight + fontSize / 2;
-        } else {
-            renderInfo.h = renderInfo.lineNum * renderInfo.lineHeight + fontSize / 2;
         }
 
         // Horizontal alignment offset

--- a/src/textures/TextTextureRendererAdvanced.mjs
+++ b/src/textures/TextTextureRendererAdvanced.mjs
@@ -119,8 +119,7 @@ export default class TextTextureRendererAdvanced {
         renderInfo.text = this._settings.text;
         renderInfo.precision = precision;
         renderInfo.fontSize = fontSize;
-        // 0 is used as the baseline ratio if none is provided so it has no impact over the browser default rendering.
-        renderInfo.fontBaselineRatio = this._settings.fontBaselineRatio || 0.0 
+        renderInfo.fontBaselineRatio = this._settings.fontBaselineRatio;
         renderInfo.lineHeight = lineHeight;
         renderInfo.letterSpacing = letterSpacing;
         renderInfo.textAlign = this._settings.textAlign;
@@ -222,9 +221,9 @@ export default class TextTextureRendererAdvanced {
         // To retrieve this ratio, you would do this calculation:
         //     (FontUnitsPerEm − hhea.Ascender − hhea.Descender) / (2 × FontUnitsPerEm)
         //
-        // This give you the ratio for the baseline, which is then used to figure out 
+        // This give you the ratio for the baseline, which is then used to figure out
         // where the baseline is relative to the bottom of the text bounding box.
-        const baselineOffsetInPx = renderInfo.fontBaselineRatio * renderInfo.fontSize
+        const baselineOffsetInPx = renderInfo.fontBaselineRatio * renderInfo.fontSize;
 
         // Vertical align
         let vaOffset = 0;


### PR DESCRIPTION
Using metadata from fonts with the advanced text renderer users will now be able to set their font baseline ratio.

This enables users to vertically position text accurately within the rasterized text canvas, so that further positioning is accurate.

In addition, the calculation of the height of the text canvas has changed when line height is greater than the font size and the previous calculation of maxLines is not met. 

This is one section I'd appreciate a double-check on. I'm not super familiar with rendering a baseline that is `'ideographic'`. If the font was parsed and the default line height was set from metrics in the fonts, I think it would be ok (the change), but given that the line height defaults to font size when unset, it's possible this change could result in some fonts rendering slightly off-canvas if no baseline ratio is given.

The calculations as they existed are an average that approximates many fonts, but for fonts with high baselines, you end up with text that tends to be higher than intended in the canvas representation when a middle vertical alignment is given.
As well, the canvas was always larger than other renderers would attribute to the same text, which was an issue for content-based fits, like Flexbox.

Visuals:

With a proper baseline, line height, and vertical alignment set to middle, here is the result on the rasterized canvas.

![Screen Shot 2022-04-20 at 1 49 53 PM](https://user-images.githubusercontent.com/1956521/164282378-c4982317-e983-410d-bfd7-a9859eecdcf1.png)

With no font baseline information, but line height and vertical alignment set to middle here is the result.

![Screen Shot 2022-04-20 at 1 47 26 PM](https://user-images.githubusercontent.com/1956521/164282255-194e7449-5413-4b5a-92df-ac816bdca025.png)

Original Visual:

If you remove the change to the canvas size, and have no font baseline information, here is the current result today.

![image](https://user-images.githubusercontent.com/1956521/164282949-85568493-b5ac-46bd-8dd6-cc0b9d9281af.png)

So, I hope these visuals makes it clear. Essentially, by oversizing the canvas, you ended up closely approximating center the text for _most_ font baselines. But you have a much larger canvas than necessary, which means size of items are larger than expected.

References:
https://opentype.js.org/font-inspector.html - useful for calculating your font baseline ratio
https://docs.microsoft.com/en-us/typography/opentype/spec/os2#stypoascender
https://docs.microsoft.com/en-us/typography/opentype/spec/os2#stypodescender