### PR TITLE
Added glReadPixels support after rendering

### DIFF
--- a/src/tree/Stage.mjs
+++ b/src/tree/Stage.mjs
@@ -186,6 +186,7 @@ export default class Stage extends EventEmitter {
         opt('canvas2d', false);
         opt('platform', null);
         opt('readPixelsBeforeDraw', false);
+        opt('readPixelsAfterDraw', false);
     }
 
     setApplication(app) {

--- a/src/tree/core/CoreContext.mjs
+++ b/src/tree/core/CoreContext.mjs
@@ -100,13 +100,23 @@ export default class CoreContext {
         this._fillRenderState();
 
         if (this.stage.getOption('readPixelsBeforeDraw')) {
-            const pixels = new Uint8Array(4);
-            const gl = this.stage.gl;
-            gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
+            this._readPixels();
         }
 
         // Now run them with the render executor.
         this._performRender();
+
+        // Block OpenGL pipeline to prevent framebuffer flickering
+        // on certain devices
+        if (this.stage.getOption('readPixelsAfterDraw')) {
+            this._readPixels();
+        }
+    }
+
+    _readPixels() {
+        const pixels = new Uint8Array(4);
+        const gl = this.stage.gl;
+        gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
     }
 
     _fillRenderState() {


### PR DESCRIPTION
Tested on Tizen 6.0.

The main issue was that when `this._performRender();` was called, it caused flickerings and sometimes the elements even disappeared from the screen.

Since this is something you activate through a specific stage configuration, it looks good to me to merge this into a new version of the Lightning core. We really need this feature/fix because we are targeting these devices and this PR fixes it.