### PR TITLE
Added option to force canvas element as tx source

### DIFF
--- a/docs/RuntimeConfig/index.md
+++ b/docs/RuntimeConfig/index.md
@@ -43,6 +43,9 @@ const App = new MyApp(options);
 | `useImageWorker` | Boolean | true | By default, use a Web Worker that parses images off-thread (web only) |
 | `autostart` | Boolean | true | If set to *false*, no automatic binding to  `requestAnimationFrame` |
 | `canvas2d` | Boolean | false | If set tot *true*, the Render Engine uses canvas2d instead of WebGL (limitations apply, see details below) |
+| `readPixelsBeforeDraw` | Boolean | false | If set tot *true*, forces the Render Engine to readPixels before drawing, turning the Render pipeline to synchronous (this helps with flickering artifacts on certain devices). Note this will affect performance! |
+| `readPixelsAfterDraw` | Boolean | false | If set tot *true*, forces the Render Engine to readPixels after drawing turning the Render pipeline synchronous (this helps with flickering artifacts on certain devices). Note this will affect performance! |
+| `forceTxCanvasSource` | Boolean | false | If set tot *true*, forces the Render Engine to use the canvasSource over getImageData for text (this helps with text generation on certain devices). |
 
 
 

--- a/src/platforms/browser/WebPlatform.mjs
+++ b/src/platforms/browser/WebPlatform.mjs
@@ -78,7 +78,7 @@ export default class WebPlatform {
             // Web-specific data types.
             gl.texImage2D(gl.TEXTURE_2D, 0, options.internalFormat, options.format, options.type, source);
         } else if (source instanceof HTMLCanvasElement) {
-            if (Utils.isZiggo) {
+            if (Utils.isZiggo || this.stage.getOption("forceTxCanvasSource")) {
                 // Ziggo EOS and Selene have issues with getImageData implementation causing artifacts.
                 gl.texImage2D(gl.TEXTURE_2D, 0, options.internalFormat, options.format, options.type, source);
             } else {

--- a/src/tree/Stage.mjs
+++ b/src/tree/Stage.mjs
@@ -187,6 +187,7 @@ export default class Stage extends EventEmitter {
         opt('platform', null);
         opt('readPixelsBeforeDraw', false);
         opt('readPixelsAfterDraw', false);
+        opt('forceTxCanvasSource', false);
     }
 
     setApplication(app) {


### PR DESCRIPTION
More reportings of rendering issue similar to #363, this adds a stage option to force `HtmlCanvasElement` as source to prevent having to add exceptions for each individual platform