### PR TITLE
Feature/track vram usage

### DIFF
--- a/src/renderer/webgl/WebGLRenderer.mjs
+++ b/src/renderer/webgl/WebGLRenderer.mjs
@@ -109,11 +109,11 @@ export default class WebGLRenderer extends Renderer {
                 case gl.UNSIGNED_BYTE:
                     return 4;
 
-                case gl.UNSIGNED_SHORT_4_4_4_$:
+                case gl.UNSIGNED_SHORT_4_4_4_4:
                     return 2;
 
                 case gl.UNSIGNED_SHORT_5_5_5_1:
-                    return 1;
+                    return 2;
 
                 default:
                     throw new Error('Invalid type specified for GL_RGBA format');

--- a/src/renderer/webgl/WebGLRenderer.mjs
+++ b/src/renderer/webgl/WebGLRenderer.mjs
@@ -101,6 +101,42 @@ export default class WebGLRenderer extends Renderer {
         gl.deleteTexture(glTexture);
     }
 
+    _getBytesPerPixel(fmt, type) {
+        const gl = this.stage.gl;
+        
+        if (fmt == gl.RGBA) {
+            switch(type) {
+                case gl.UNSIGNED_BYTE:
+                    return 4;
+
+                case gl.UNSIGNED_SHORT_4_4_4_$:
+                    return 2;
+
+                case gl.UNSIGNED_SHORT_5_5_5_1:
+                    return 1;
+
+                default:
+                    throw new Error('Invalid type specified for GL_RGBA format');
+            }
+        }
+        else if (fmt == gl.RGB) {
+            switch(type) {
+                case gl.UNSIGNED_BYTE:
+                    return 3;
+
+                case gl.UNSIGNED_BYTE_5_6_5:
+                    return 2;
+
+                default:
+                    throw new Error('Invalid type specified for GL_RGB format');
+            }
+        }
+        else
+        {
+            throw new Error('Invalid format specified in call to _getBytesPerPixel()');
+        }
+    }
+
     uploadTextureSource(textureSource, options) {
         const gl = this.stage.gl;
 
@@ -162,6 +198,9 @@ export default class WebGLRenderer extends Renderer {
 
         glTexture.params = Utils.cloneObjShallow(texParams);
         glTexture.options = Utils.cloneObjShallow(texOptions);
+
+        // calculate bytes per pixel for vram usage tracking
+        glTexture.bytesPerPixel = this._getBytesPerPixel(texOptions.format, texOptions.type);
 
         return glTexture;
     }

--- a/src/tree/Stage.mjs
+++ b/src/tree/Stage.mjs
@@ -39,6 +39,10 @@ export default class Stage extends EventEmitter {
         this._usedMemory = 0;
         this._lastGcFrame = 0;
 
+        // attempt to track VRAM usage more accurately by accounting for different color channels
+        this._usedVramAlpha = 0;
+        this._usedVramNonAlpha = 0;
+
         const platformType = Stage.platform ? Stage.platform : PlatformLoader.load(options);
         this.platform = new platformType();
 
@@ -394,6 +398,27 @@ export default class Stage extends EventEmitter {
 
     get usedMemory() {
         return this._usedMemory;
+    }
+
+    addVramUsage(delta, alpha) {
+        if (alpha) {
+            this._usedVramAlpha += delta;
+        }
+        else {
+            this._usedVramNonAlpha += delta;
+        }
+    }
+
+    get usedVramAlpha() {
+        return this._usedVramAlpha;
+    }
+
+    get usedVramNonAlpha() {
+        return this._usedVramNonAlpha;
+    }
+
+    get usedVram() {
+        return this._usedVramAlpha + this._usedVramNonAlpha;
     }
 
     gc(aggressive) {

--- a/src/tree/TextureManager.mjs
+++ b/src/tree/TextureManager.mjs
@@ -160,12 +160,10 @@ export default class TextureManager {
 
     _freeManagedTextureSource(textureSource) {
         if (textureSource.isLoaded()) {
-            // add VRAM tracking if using the webgl renderer
-            this._updateVramUsage(textureSource, -1);
-
             this._nativeFreeTextureSource(textureSource);
             this._addMemoryUsage(-textureSource.w * textureSource.h);
 
+            // add VRAM tracking if using the webgl renderer
             this._updateVramUsage(textureSource, -1);
         }
 

--- a/src/tree/TextureManager.mjs
+++ b/src/tree/TextureManager.mjs
@@ -18,6 +18,7 @@
  */
 
 import TextureSource from "./TextureSource.mjs";
+import Stage from './Stage.mjs';
 
 export default class TextureManager {
 
@@ -96,13 +97,37 @@ export default class TextureManager {
         this._uploadedTextureSources.push(textureSource);
         
         this.addToLookupMap(textureSource);
+
+        // add VRAM tracking if using the webgl renderer
+        this._updateVramUsage(textureSource, 1);
     }
 
     _addMemoryUsage(delta) {
         this._usedMemory += delta;
         this.stage.addMemoryUsage(delta);
     }
-    
+
+    _updateVramUsage(textureSource, sign) {
+        const nativeTexture = textureSource.nativeTexture;
+        var usage;
+
+        // do nothing if webgl isn't even supported
+        if (!Stage.isWebglSupported())
+            return;
+
+        // or if there is no native texture
+        if (!textureSource.isLoaded())
+            return;
+
+        // or, finally, if there is no bytes per pixel specified
+        if (!nativeTexture.hasOwnProperty('bytesPerPixel') || isNaN(nativeTexture.bytesPerPixel))
+            return;
+
+        usage = sign * (textureSource.w * textureSource.h * nativeTexture.bytesPerPixel);
+
+        this.stage.addVramUsage(usage, textureSource.hasAlpha);
+    }
+
     addToLookupMap(textureSource) {
         const lookupId = textureSource.lookupId;
         if (lookupId) {
@@ -135,8 +160,13 @@ export default class TextureManager {
 
     _freeManagedTextureSource(textureSource) {
         if (textureSource.isLoaded()) {
+            // add VRAM tracking if using the webgl renderer
+            this._updateVramUsage(textureSource, -1);
+
             this._nativeFreeTextureSource(textureSource);
             this._addMemoryUsage(-textureSource.w * textureSource.h);
+
+            this._updateVramUsage(textureSource, -1);
         }
 
         // Should be reloaded.

--- a/src/tree/TextureSource.mjs
+++ b/src/tree/TextureSource.mjs
@@ -102,6 +102,17 @@ export default class TextureSource {
          */
         this._imageRef = null;
 
+
+        /**
+         * Track whether or not there is an alpha channel in this source
+         * @type {boolean}
+         * @private
+         */
+         this._hasAlpha = false;
+    }
+
+    get hasAlpha() {
+        return this._hasAlpha;
     }
 
     get loadError() {
@@ -256,6 +267,7 @@ export default class TextureSource {
     setSource(options) {
         const source = options.source;
 
+        this._hasAlpha = (options ? (options.hasAlpha || false) : false);
         this.w = source.width || (options && options.w) || 0;
         this.h = source.height || (options && options.h) || 0;
 


### PR DESCRIPTION
Adds a separate usage variable to Stage to track texture VRAM usage separately, for more accurate memory usage statistics as the memoryUsage only tracks pixel count and not byte count