### PR TITLE
Mitigate RAF usage

### DIFF
--- a/docs/RuntimeConfig/index.md
+++ b/docs/RuntimeConfig/index.md
@@ -43,10 +43,10 @@ const App = new MyApp(options);
 | `useImageWorker` | Boolean | true | By default, use a Web Worker that parses images off-thread (web only) |
 | `autostart` | Boolean | true | If set to *false*, no automatic binding to  `requestAnimationFrame` |
 | `canvas2d` | Boolean | false | If set tot *true*, the Render Engine uses canvas2d instead of WebGL (limitations apply, see details below) |
-| `readPixelsBeforeDraw` | Boolean | false | If set tot *true*, forces the Render Engine to readPixels before drawing, turning the Render pipeline to synchronous (this helps with flickering artifacts on certain devices). Note this will affect performance! |
-| `readPixelsAfterDraw` | Boolean | false | If set tot *true*, forces the Render Engine to readPixels after drawing turning the Render pipeline synchronous (this helps with flickering artifacts on certain devices). Note this will affect performance! |
-| `forceTxCanvasSource` | Boolean | false | If set tot *true*, forces the Render Engine to use the canvasSource over getImageData for text (this helps with text generation on certain devices). |
-
+| `readPixelsBeforeDraw` | Boolean | false | If set to *true*, forces the Render Engine to readPixels before drawing, turning the Render pipeline to synchronous (this helps with flickering artifacts on certain devices). Note this will affect performance! |
+| `readPixelsAfterDraw` | Boolean | false | If set to *true*, forces the Render Engine to readPixels after drawing turning the Render pipeline synchronous (this helps with flickering artifacts on certain devices). Note this will affect performance! |
+| `forceTxCanvasSource` | Boolean | false | If set to *true*, forces the Render Engine to use the canvasSource over getImageData for text (this helps with text generation on certain devices). |
+| `pauseRafLoopOnIdle` | Boolean | false | If set to *true* will stop the Render Engine from calling `RequestAnimationFrame` when there are no stage updates. |
 
 
 

--- a/src/platforms/browser/WebPlatform.mjs
+++ b/src/platforms/browser/WebPlatform.mjs
@@ -94,8 +94,9 @@ export default class WebPlatform {
             self._awaitingLoop = false;
             if (self._looping) {
                 self.stage.updateFrame();
-                self.switchLoop();
-                console.log('Active loop', self.stage.ctx.hasRenderUpdates());
+                if (self.stage.getOption("pauseRafLoopOnIdle")) {
+                    self.switchLoop();
+                }
                 self.stage.drawFrame();
                 requestAnimationFrame(lp);
                 self._awaitingLoop = true;

--- a/src/platforms/browser/WebPlatform.mjs
+++ b/src/platforms/browser/WebPlatform.mjs
@@ -30,6 +30,11 @@ export default class WebPlatform {
         this._looping = false;
         this._awaitingLoop = false;
 
+        // Alternative handler to avoid RAF when idle
+        this._loopHandler = null;
+        this._idleLoopCounter = 0;
+        this._idleLoopDelay = 60;
+
         if (this.stage.getOption("useImageWorker")) {
             if (!window.createImageBitmap || !window.Worker) {
                 console.warn("[Lightning] Can't use image worker because browser does not have createImageBitmap and Web Worker support");
@@ -63,11 +68,34 @@ export default class WebPlatform {
         this._looping = false;
     }
 
+    switchLoop() {
+        if (this._idleLoopCounter < this._idleLoopDelay) {
+            this._idleLoopCounter++;
+            return;
+        }
+        if (!this.stage.ctx.hasRenderUpdates()) {
+            this.stopLoop();
+            this._loopHandler = setInterval(() => {
+                this.stage.updateFrame();
+                this.stage.idleFrame();
+                if (this.stage.ctx.hasRenderUpdates()) {
+                    clearInterval(this._loopHandler);
+                    this.startLoop();
+                };
+            }, 1000 / 60);
+        } else {
+            this._idleLoopCounter = 0;
+        }
+    }
+
     loop() {
         let self = this;
         let lp = function() {
             self._awaitingLoop = false;
             if (self._looping) {
+                self.stage.updateFrame();
+                self.switchLoop();
+                console.log('Active loop', self.stage.ctx.hasRenderUpdates());
                 self.stage.drawFrame();
                 requestAnimationFrame(lp);
                 self._awaitingLoop = true;

--- a/src/tree/Stage.mjs
+++ b/src/tree/Stage.mjs
@@ -261,7 +261,17 @@ export default class Stage extends EventEmitter {
         return (this._updateSourceTextures && this._updateSourceTextures.has(texture));
     }
 
-    drawFrame() {
+
+    _performUpdateSource() {
+        if (this._updateSourceTextures.size) {
+            this._updateSourceTextures.forEach(texture => {
+                texture._performUpdateSource();
+            });
+            this._updateSourceTextures = new Set();
+        }
+    }
+
+    _calculateDt() {
         this.startTime = this.currentTime;
         this.currentTime = this.platform.getHrTime();
 
@@ -270,18 +280,22 @@ export default class Stage extends EventEmitter {
         } else {
             this.dt = (!this.startTime) ? .02 : .001 * (this.currentTime - this.startTime);
         }
+    }
 
+    updateFrame() {
+        this._calculateDt();
         this.emit('frameStart');
-
-        if (this._updateSourceTextures.size) {
-            this._updateSourceTextures.forEach(texture => {
-                texture._performUpdateSource();
-            });
-            this._updateSourceTextures = new Set();
-        }
-
+        this._performUpdateSource();
         this.emit('update');
+    }
 
+    idleFrame() {
+        this.textureThrottler.processSome();
+        this.emit('frameEnd');
+        this.frameCounter++;
+    }
+
+    drawFrame() {
         const changes = this.ctx.hasRenderUpdates();
 
         // Update may cause textures to be loaded in sync, so by processing them here we may be able to show them

--- a/src/tree/Stage.mjs
+++ b/src/tree/Stage.mjs
@@ -188,6 +188,7 @@ export default class Stage extends EventEmitter {
         opt('readPixelsBeforeDraw', false);
         opt('readPixelsAfterDraw', false);
         opt('forceTxCanvasSource', false);
+        opt('pauseRafLoopOnIdle', false);
     }
 
     setApplication(app) {


### PR DESCRIPTION
When there are no stage updates the Render Engine will stop calling RAF. This will be resumed once there are updates pending. 