### PR TITLE
Documentation Fixes

### DIFF
--- a/docs/RenderEngine/Textures/Toolbox.md
+++ b/docs/RenderEngine/Textures/Toolbox.md
@@ -9,7 +9,7 @@ The `lng.Tools` Class contains useful functions for creating some commonly used 
 |---|---|
 | Rounded rectangle | `lng.Tools.getRoundRect(w, h, radius, strokeWidth, strokeColor, fill, fillColor)` |
 | Drop-shadow rectangle | `lng.Tools.getShadowRect(w, h, radius = 0, blur = 5, margin = blur * 2)` |
-| SVG rendering | `lng.Tools.createSvg(cb, stage, url, w, h)` |
+| SVG rendering | `lng.Tools.getSvgTexture(url, w, h)` |
 
 
 ## Live Demo
@@ -31,6 +31,12 @@ class TextureDemo extends lng.Application {
                 zIndex: 1,
                 color: 0x66000000,
                 texture: lng.Tools.getShadowRect(150, 40, 4, 10, 15),
+            },
+            Svg: {
+                x: 10,
+                y: 50,
+                zIndex: 0,
+                texture: lng.Tools.getSvgTexture(Utils.asset('images/image.svg'), 50, 50),
             }
         }
     }

--- a/docs/Transitions/Methods.md
+++ b/docs/Transitions/Methods.md
@@ -26,7 +26,7 @@ To call a transition method, you have to get the correct transition `property` f
 
 ```
 _init(){
-   this.tag('MyObject').transition('x').start();
+   this.tag('MyObject').transition('x').start(100);
 }
 ```
 
@@ -34,12 +34,11 @@ _init(){
 
 | Name | Description |
 |---|---|
-| `start()` | Start (or restart if already running) the transition |
+| `start(targetValue : number)` | Start a new transition (similar to calling `setSmooth()`) |
 | `stop()` | Stop the transition (at the current value) |
 | `pause()` | Alias for `stop()` |
 | `play()` | Resume the paused transition |
 | `finish()` | Fast-forward the transition (to the target value) |
-| `start(targetValue : number)` | Start a new transition (similar to calling `setSmooth()`) |
 | `reset(targetValue : number, p : number)` | Set the transition at a specific point in time (where p is a value between 0 and 1) |
 | `updateTargetValue(targetValue : number)` | Update the target value while keeping the current progress and value |
 


### PR DESCRIPTION
- docs/RenderEngine/Textures/Toolbox.md
  - `Tools.getSvgTexture()` is used to get an SVG texture, not `Tools.createSvg()`
    - `createSvg()` just returns an HTMLCanvasElement via a callback method and is used by `getSvgTexture()`
- docs/Transitions/Methods.md
  - `transition.start()` requires a targetValue