### PR TITLE
Don't compute a value that is always 10

### DIFF
--- a/src/textures/TextTextureRenderer.mjs
+++ b/src/textures/TextTextureRenderer.mjs
@@ -120,7 +120,7 @@ export default class TextTextureRenderer {
         let innerWidth = width - (paddingLeft);
         if (innerWidth < 10) {
             width += (10 - innerWidth);
-            innerWidth += (10 - innerWidth);
+            innerWidth = 10;
         }
 
         if (!wordWrapWidth) {


### PR DESCRIPTION
```
innerWidth += (10 - innerWidth);
innerWidth = innerWidth + (10 - innerWidth);
innerWidth = innerWidth + (10 + (-innerWidth));
innerWidth = innerWidth + 10 + (-innerWidth);
innerWidth = 10 // innerWidth and (-innerWidth) cancel each other out
```

![image](https://user-images.githubusercontent.com/102993297/181620640-56e9b5d2-df0f-4121-afc5-be89881e63af.png)
