### PR TITLE
fix: Revert original functionality of drawFrame()

### DIFF
--- a/src/platforms/browser/WebPlatform.mjs
+++ b/src/platforms/browser/WebPlatform.mjs
@@ -97,7 +97,7 @@ export default class WebPlatform {
                 if (self.stage.getOption("pauseRafLoopOnIdle")) {
                     self.switchLoop();
                 }
-                self.stage.drawFrame();
+                self.stage.renderFrame();
                 requestAnimationFrame(lp);
                 self._awaitingLoop = true;
             }
@@ -306,7 +306,7 @@ export default class WebPlatform {
         this._visibilityChangeHandler = () => {
             if (document.visibilityState === 'visible') {
                 this.stage.root.core.setHasRenderUpdates(2);
-                this.stage.drawFrame();
+                this.stage.renderFrame();
             }
         }
         document.addEventListener('visibilitychange', this._visibilityChangeHandler);

--- a/src/tree/Stage.d.mts
+++ b/src/tree/Stage.d.mts
@@ -368,10 +368,9 @@ declare class Stage extends EventEmitter<Stage.EventMap> {
   // - Internal Use Only
 
   /**
-   * Draws a new frame
+   * Updates and renders a new frame
    */
-  // drawFrame(): void;
-  // - Internal Use Only
+  drawFrame(): void;
 
   /**
    * Returns `true` if the frame is currently updating
@@ -379,7 +378,7 @@ declare class Stage extends EventEmitter<Stage.EventMap> {
   isUpdatingFrame(): boolean;
 
   // renderFrame(): void;
-  // - Dead code
+  // - Internal Use Only
 
   /**
    * Force a re-render

--- a/src/tree/Stage.mjs
+++ b/src/tree/Stage.mjs
@@ -296,7 +296,7 @@ export default class Stage extends EventEmitter {
         this.frameCounter++;
     }
 
-    drawFrame() {
+    renderFrame() {
         const changes = this.ctx.hasRenderUpdates();
 
         // Update may cause textures to be loaded in sync, so by processing them here we may be able to show them
@@ -321,8 +321,13 @@ export default class Stage extends EventEmitter {
         return this._updatingFrame;
     }
 
-    renderFrame() {
-        this.ctx.frame();
+    drawFrame() {
+        // Maintain original functionality of `drawFrame()` while retaining the
+        // RAF mitigration feature from: https://github.com/rdkcentral/Lightning/pull/402
+        // The full functionality of this method is relied directly by our own unit tests and
+        // the unit tests of third party users
+        this.updateFrame();
+        this.renderFrame();
     }
 
     forceRenderUpdate() {


### PR DESCRIPTION
Functionality of Stage's `drawFrame()` was changed in #402 (Mitigate RAF usage). This is causing grief in our own unit tests as well as unit tests of third party users.

This simple change reverts the original functionality while retaining the new RAF feature.

Here we rename the post-RAF `drawFrame()` method to `renderFrame()`, the name of an existing but verifiably dead method (see below). We then create a new `drawFrame()` which implements its pre-RAF behavior by simply calling `updateFrame()` followed by `renderFrame()`.

The original Stage `renderFrame()` method that is being hijacked here is not used elsewhere in the project (nor the SDK). As for possible third party client uses, this is extremely unlikely given that the `this.ctx.frame` method it calls does not even exist in CoreContext today and would result in an exception if ever attempted. It was removed/renamed by basvanmeurs over 3 years ago (Apr 2019) in 6e0cb2fc0c9335a72bb0b24e578be86ed1acf9eb.

Incidentally, the naming of the functions as `updateFrame()` and `renderFrame()` lines up perfectly with the original function names used in the aforementioned commit.
