### PR TITLE
fix: Add missing 'pauseRafLoopOnIdle' stage option type def + small doc updates

### DIFF
--- a/docs/RuntimeConfig/index.md
+++ b/docs/RuntimeConfig/index.md
@@ -45,7 +45,7 @@ const App = new MyApp(options);
 | `canvas2d` | Boolean | false | If set tot *true*, the Render Engine uses canvas2d instead of WebGL (limitations apply, see details below) |
 | `readPixelsBeforeDraw` | Boolean | false | If set to *true*, forces the Render Engine to readPixels before drawing, turning the Render pipeline to synchronous (this helps with flickering artifacts on certain devices). Note this will affect performance! |
 | `readPixelsAfterDraw` | Boolean | false | If set to *true*, forces the Render Engine to readPixels after drawing turning the Render pipeline synchronous (this helps with flickering artifacts on certain devices). Note this will affect performance! |
-| `forceTxCanvasSource` | Boolean | false | If set to *true*, forces the Render Engine to use the canvasSource over getImageData for text (this helps with text generation on certain devices). |
+| `forceTxCanvasSource` | Boolean | false | If set to *true*, forces the Render Engine to use the canvasSource over getImageData for canvas textures (this helps with text generation on certain devices). |
 | `pauseRafLoopOnIdle` | Boolean | false | If set to *true* will stop the Render Engine from calling `RequestAnimationFrame` when there are no stage updates. |
 
 

--- a/src/tree/Stage.d.mts
+++ b/src/tree/Stage.d.mts
@@ -194,8 +194,6 @@ declare namespace Stage {
      *
      * Note: This will affect performance!
      *
-     * See [PR #393](https://github.com/rdkcentral/Lightning/pull/393) for more information about this option.
-     *
      * @defaultValue `false`
      * @see {@link readPixelsAfterDraw}
      */
@@ -209,15 +207,15 @@ declare namespace Stage {
      *
      * Note: This will affect performance!
      *
-     * See [PR #393](https://github.com/rdkcentral/Lightning/pull/393) for more information about this option.
+     * See [PR #388](https://github.com/rdkcentral/Lightning/pull/388) for more information about this option.
      *
      * @defaultValue `false`
      * @see {@link readPixelsBeforeDraw}
      */
     readPixelsAfterDraw: boolean;
-
     /**
-     * If set to `true`, forces the Render Engine to use the canvasSource over getImageData for text
+     * If set to `true`, forces the Render Engine to use the canvasSource over getImageData for canvas
+     * textures.
      *
      * @remarks
      * This helps with text generation on certain devices.
@@ -227,8 +225,17 @@ declare namespace Stage {
      * @defaultValue `false`
      */
     forceTxCanvasSource: boolean;
+    /**
+     * If set to `true`, will stop the Render Engine from calling `RequestAnimationFrame` when there are no
+     * stage updates.
+     *
+     * @remarks
+     * See [Issue #380](https://github.com/rdkcentral/Lightning/issues/380) for more information about this option.
+     *
+     * @defaultValue `false`
+     */
+    pauseRafLoopOnIdle: boolean;
   }
-
   /**
    * Events produced by Stage along with their handler signatures
    */


### PR DESCRIPTION
- New 'pauseRafLoopOnIdle' stage option was inadvertently missed from TypeScript defs
- Small updates to other Stage options TSDoc
- Update MD doc on 'forceTxCanvasSource' to emphasize that it effects rendering of any canvas texture (not just text)