### PR TITLE
fix text rendering issues on Ziggo EOS2

### DIFF
--- a/src/tree/Utils.mjs
+++ b/src/tree/Utils.mjs
@@ -195,4 +195,4 @@ Utils.isWPE = Utils.isWeb && (navigator.userAgent.indexOf("WPE") !== -1);
 Utils.isSpark = (typeof sparkscene !== "undefined");
 Utils.isNode = (typeof window === "undefined") || Utils.isSpark;
 Utils.isPS4 = Utils.isWeb && (navigator.userAgent.indexOf("PlayStation 4") !== -1);
-Utils.isZiggo = Utils.isWeb && (navigator.userAgent.indexOf("EOSSTB") !== -1 || navigator.userAgent.indexOf("HZNSTB") !== -1);
+Utils.isZiggo = Utils.isWeb && (/(eos2?|hzn)stb/i.test(navigator.userAgent));


### PR DESCRIPTION
Besides EOS and Horizon there is also an EOS2STB device. Here is a sample of it's UA: Mozilla/5.0 (Linux armv7l) AppleWebKit/602.1.28+ (KHTML, like Gecko) Version/9.1 Safari/601.5.17 HZN/4.46 (MN=2008C-STB-DEV;PC=EOS2STB;FV=EOS2008C-mon-dbg-00.05-000-aa-AL-20220920210002-un000;) Hence, #364 is not fully fixing the text rendering issue on all Ziggo devices and we need to include EOS2 as well.