### PR TITLE
Expose package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
         "types": "./dist/lightning.js",
         "default": "./index.d.ts"
       }
-    }
+    },
+    "./package.json": "./package.json"
   },
   "files": [
     "tsconfig.json",


### PR DESCRIPTION
Some of the scripts in the MAF-Lightning repo rely on importing the Lightning version from the `package.json`. We might want to revise this in the future, but for now this fixes our issue. 