### PR TITLE
fix: order same zIndex elements by updateTreeOrder

### DIFF
--- a/src/tree/core/ElementCore.mjs
+++ b/src/tree/core/ElementCore.mjs
@@ -2031,6 +2031,7 @@ export default class ElementCore {
                     a.splice(ptr);
                 }
             } else {
+                a.sort(ElementCore.sortZIndexedChildren); // Needed because items with same _zIndex may not be ordered by _updateTreeOrder
                 // Merge-sort arrays;
                 ptr = 0;
                 let i = 0;

--- a/src/tree/core/ElementCore.mjs
+++ b/src/tree/core/ElementCore.mjs
@@ -2031,7 +2031,7 @@ export default class ElementCore {
                     a.splice(ptr);
                 }
             } else {
-                a.sort(ElementCore.sortZIndexedChildren); // Needed because items with same _zIndex may not be ordered by _updateTreeOrder
+                a.sort(ElementCore.sortSameZIndexedChildren); // Needed because items with same _zIndex may not be ordered by _updateTreeOrder
                 // Merge-sort arrays;
                 ptr = 0;
                 let i = 0;
@@ -2273,6 +2273,9 @@ class ElementCoreContext {
 ElementCoreContext.IDENTITY = new ElementCoreContext();
 ElementCore.sortZIndexedChildren = function (a, b) {
     return (a._zIndex === b._zIndex ? a._updateTreeOrder - b._updateTreeOrder : a._zIndex - b._zIndex);
+};
+ElementCore.sortSameZIndexedChildren = function (a, b) {
+    return (a._zIndex === b._zIndex ? a._updateTreeOrder - b._updateTreeOrder : 0);
 };
 
 import ElementTexturizer from "./ElementTexturizer.mjs";

--- a/src/tree/core/ElementCore.mjs
+++ b/src/tree/core/ElementCore.mjs
@@ -2032,7 +2032,7 @@ export default class ElementCore {
                 }
             } else {
                 a.splice(n); // Remove items that were sorted in b array, so that we can sort a
-+               // Beware that the function passed here to Array.sort must be stable https://jira.inbcu.com/browse/PCKLTV-8916
++               // Beware that the function passed here to Array.sort must be stable
 +               a.sort(ElementCore.sortZIndexedChildren); // Needed because items with same _zIndex may not be ordered by _updateTreeOrder
                 // Merge-sort arrays;
                 ptr = 0;

--- a/src/tree/core/ElementCore.mjs
+++ b/src/tree/core/ElementCore.mjs
@@ -2031,7 +2031,9 @@ export default class ElementCore {
                     a.splice(ptr);
                 }
             } else {
-                a.sort(ElementCore.sortSameZIndexedChildren); // Needed because items with same _zIndex may not be ordered by _updateTreeOrder
+                a.splice(n); // Remove items that were sorted in b array, so that we can sort a
++               // Beware that the function passed here to Array.sort must be stable https://jira.inbcu.com/browse/PCKLTV-8916
++               a.sort(ElementCore.sortZIndexedChildren); // Needed because items with same _zIndex may not be ordered by _updateTreeOrder
                 // Merge-sort arrays;
                 ptr = 0;
                 let i = 0;
@@ -2273,9 +2275,6 @@ class ElementCoreContext {
 ElementCoreContext.IDENTITY = new ElementCoreContext();
 ElementCore.sortZIndexedChildren = function (a, b) {
     return (a._zIndex === b._zIndex ? a._updateTreeOrder - b._updateTreeOrder : a._zIndex - b._zIndex);
-};
-ElementCore.sortSameZIndexedChildren = function (a, b) {
-    return (a._zIndex === b._zIndex ? a._updateTreeOrder - b._updateTreeOrder : 0);
 };
 
 import ElementTexturizer from "./ElementTexturizer.mjs";


### PR DESCRIPTION
When elements have the same zIndex they should respect the renderTree. There is a clear attempt at that by using the updateTreeOrder to sort the elements, however the code that triggered the re-sort was removed:

https://github.com/rdkcentral/Lightning/commit/38285e00ef018a23f11e0943507da20f793090db
https://github.com/rdkcentral/Lightning/commit/93b301b5157b73119a967e3c52954a09389da1dc

Since this sort happens only when the tree changes it has a very very low cost, performance wise and is much better than having a wrongly ordered zIndex array.

Other suggestions to fix this bug are very welcome.