### PR TITLE
Improve text renderer font default

### DIFF
--- a/src/textures/TextTexture.mjs
+++ b/src/textures/TextTexture.mjs
@@ -534,11 +534,6 @@ export default class TextTexture extends Texture {
     _getSourceLoader() {
         const args = this.cloneArgs();
 
-        // Inherit font face from stage.
-        if (args.fontFace === null) {
-            args.fontFace = this.stage.getOption('defaultFontFace');
-        }
-
         const gl = this.stage.gl;
 
         return function (cb) {

--- a/src/textures/TextTextureRenderer.mjs
+++ b/src/textures/TextTextureRenderer.mjs
@@ -36,11 +36,11 @@ export default class TextTextureRenderer {
 
     setFontProperties() {
         this._context.font = getFontSetting(
-            this._stage,
             this._settings.fontFace,
             this._settings.fontStyle,
             this._settings.fontSize,
-            this.getPrecision()
+            this.getPrecision(),
+            this._stage.getOption('defaultFontFace'),
         );
         this._context.textBaseline = this._settings.textBaseline;
     };
@@ -48,11 +48,11 @@ export default class TextTextureRenderer {
     _load() {
         if (Utils.isWeb && document.fonts) {
             const fontSetting = getFontSetting(
-                this._stage,
                 this._settings.fontFace,
                 this._settings.fontStyle,
                 this._settings.fontSize,
-                this.getPrecision()
+                this.getPrecision(),
+                this._stage.getOption('defaultFontFace')
             );
             try {
                 if (!document.fonts.check(fontSetting, this._settings.text)) {
@@ -465,5 +465,5 @@ export default class TextTextureRenderer {
             return acc + this._context.measureText(char).width + space;
         }, 0);
     }
-    
+
 }

--- a/src/textures/TextTextureRenderer.mjs
+++ b/src/textures/TextTextureRenderer.mjs
@@ -19,6 +19,7 @@
 
 import StageUtils from "../tree/StageUtils.mjs";
 import Utils from "../tree/Utils.mjs";
+import { getFontSetting } from "./TextTextureRendererUtils.mjs";
 
 export default class TextTextureRenderer {
 
@@ -34,32 +35,25 @@ export default class TextTextureRenderer {
     };
 
     setFontProperties() {
-        this._context.font = Utils.isSpark ? this._stage.platform.getFontSetting(this) : this._getFontSetting();
+        this._context.font = getFontSetting(
+            this._stage,
+            this._settings.fontFace,
+            this._settings.fontStyle,
+            this._settings.fontSize,
+            this.getPrecision()
+        );
         this._context.textBaseline = this._settings.textBaseline;
     };
 
-    _getFontSetting() {
-        let ff = this._settings.fontFace;
-
-        if (!Array.isArray(ff)) {
-            ff = [ff];
-        }
-
-        let ffs = [];
-        for (let i = 0, n = ff.length; i < n; i++) {
-            if (ff[i] === "serif" || ff[i] === "sans-serif") {
-                ffs.push(ff[i]);
-            } else {
-                ffs.push(`"${ff[i]}"`);
-            }
-        }
-
-        return `${this._settings.fontStyle} ${this._settings.fontSize * this.getPrecision()}px ${ffs.join(",")}`
-    }
-
     _load() {
         if (Utils.isWeb && document.fonts) {
-            const fontSetting = this._getFontSetting();
+            const fontSetting = getFontSetting(
+                this._stage,
+                this._settings.fontFace,
+                this._settings.fontStyle,
+                this._settings.fontSize,
+                this.getPrecision()
+            );
             try {
                 if (!document.fonts.check(fontSetting, this._settings.text)) {
                     // Use a promise that waits for loading.

--- a/src/textures/TextTextureRendererAdvanced.mjs
+++ b/src/textures/TextTextureRendererAdvanced.mjs
@@ -36,11 +36,11 @@ export default class TextTextureRendererAdvanced {
 
     setFontProperties() {
         const font = getFontSetting(
-            this._stage,
             this._settings.fontFace,
             this._settings.fontStyle,
             this._settings.fontSize,
-            this.getPrecision()
+            this.getPrecision(),
+            this._stage.getOption('defaultFontFace')
         );
         this._context.font = font;
         this._context.textBaseline = this._settings.textBaseline;
@@ -50,11 +50,11 @@ export default class TextTextureRendererAdvanced {
     _load() {
         if (Utils.isWeb && document.fonts) {
             const fontSetting = getFontSetting(
-                this._stage,
                 this._settings.fontFace,
                 this._settings.fontStyle,
                 this._settings.fontSize,
-                this.getPrecision()
+                this.getPrecision(),
+                this._stage.getOption('defaultFontFace')
             );
             try {
                 if (!document.fonts.check(fontSetting, this._settings.text)) {
@@ -418,7 +418,7 @@ export default class TextTextureRendererAdvanced {
         if (renderInfo.cutSx || renderInfo.cutSy) {
             this._context.translate(renderInfo.cutSx, renderInfo.cutSy);
         }
- 
+
         // Postprocess renderInfo.lines to be compatible with standard version
         renderInfo.lines = renderInfo.lines.map((l) => l.text.reduce((acc, v) => acc + v.text, ''));
         if (renderInfo.maxLines) {
@@ -441,19 +441,19 @@ export default class TextTextureRendererAdvanced {
 
     tokenize(text) {
         const re =/ |\n|<i>|<\/i>|<b>|<\/b>|<color=0[xX][0-9a-fA-F]{8}>|<\/color>/g
-    
+
         const delimeters = text.match(re) || [];
         const words = text.split(re) || [];
-    
+
         let final = [];
         for (let i = 0; i < words.length; i++) {
             final.push(words[i], delimeters[i])
         }
         final.pop()
         return final.filter((word) => word != '');
-    
+
     }
-    
+
     parse(tokens) {
         let italic = 0;
         let bold = 0;
@@ -461,7 +461,7 @@ export default class TextTextureRendererAdvanced {
         let color = 0;
 
         const colorRegexp = /<color=(0[xX][0-9a-fA-F]{8})>/;
-    
+
         return tokens.map((t) => {
             if (t == '<i>') {
                 italic += 1;

--- a/src/textures/TextTextureRendererAdvanced.mjs
+++ b/src/textures/TextTextureRendererAdvanced.mjs
@@ -19,6 +19,7 @@
 
 import StageUtils from "../tree/StageUtils.mjs";
 import Utils from "../tree/Utils.mjs";
+import { getFontSetting } from "./TextTextureRendererUtils.mjs";
 
 export default class TextTextureRendererAdvanced {
 
@@ -34,34 +35,27 @@ export default class TextTextureRendererAdvanced {
     };
 
     setFontProperties() {
-        const font = Utils.isSpark ? this._stage.platform.getFontSetting(this) : this._getFontSetting();
+        const font = getFontSetting(
+            this._stage,
+            this._settings.fontFace,
+            this._settings.fontStyle,
+            this._settings.fontSize,
+            this.getPrecision()
+        );
         this._context.font = font;
         this._context.textBaseline = this._settings.textBaseline;
         return font;
     };
 
-    _getFontSetting() {
-        let ff = this._settings.fontFace;
-
-        if (!Array.isArray(ff)) {
-            ff = [ff];
-        }
-
-        let ffs = [];
-        for (let i = 0, n = ff.length; i < n; i++) {
-            if (ff[i] === "serif" || ff[i] === "sans-serif") {
-                ffs.push(ff[i]);
-            } else {
-                ffs.push(`"${ff[i]}"`);
-            }
-        }
-
-        return `${this._settings.fontStyle} ${this._settings.fontSize * this.getPrecision()}px ${ffs.join(",")}`
-    }
-
     _load() {
         if (Utils.isWeb && document.fonts) {
-            const fontSetting = this._getFontSetting();
+            const fontSetting = getFontSetting(
+                this._stage,
+                this._settings.fontFace,
+                this._settings.fontStyle,
+                this._settings.fontSize,
+                this.getPrecision()
+            );
             try {
                 if (!document.fonts.check(fontSetting, this._settings.text)) {
                     // Use a promise that waits for loading.
@@ -356,7 +350,7 @@ export default class TextTextureRendererAdvanced {
             const hlPaddingRight = (renderInfo.highlightPaddingRight !== null ? renderInfo.highlightPaddingRight * precision : renderInfo.paddingRight);
 
             this._context.fillStyle = StageUtils.getRgbaString(hlColor);
-            const lineNum = renderInfo.maxLines ? Math.min(renderInfo.maxLines, renderInfo.lineNum) : renderInfo.lineNum; 
+            const lineNum = renderInfo.maxLines ? Math.min(renderInfo.maxLines, renderInfo.lineNum) : renderInfo.lineNum;
             for (let i = 0; i < lineNum; i++) {
                 const l = renderInfo.lines[i];
                 this._context.fillRect(l.x - hlPaddingLeft + paddingLeft, l.y + hlOffset, l.width + hlPaddingLeft + hlPaddingRight, hlHeight);

--- a/src/textures/TextTextureRendererUtils.mjs
+++ b/src/textures/TextTextureRendererUtils.mjs
@@ -2,14 +2,14 @@
  * Returns CSS font setting string for use in canvas context.
  *
  * @private
- * @param {Stage} stage
  * @param {string | string[]} fontFace
  * @param {string} fontStyle
  * @param {number} fontSize
  * @param {number} precision
+ * @param {string} defaultFontFace
  * @returns {string}
  */
-export function getFontSetting(stage, fontFace, fontStyle, fontSize, precision) {
+export function getFontSetting(fontFace, fontStyle, fontSize, precision, defaultFontFace) {
     let ff = fontFace;
 
     if (!Array.isArray(ff)) {
@@ -22,7 +22,7 @@ export function getFontSetting(stage, fontFace, fontStyle, fontSize, precision) 
         // Replace the default font face `null` with the actual default font face set
         // on the stage.
         if (curFf === null) {
-            curFf = stage.getOption('defaultFontFace');
+            curFf = defaultFontFace;
         }
         if (curFf === "serif" || curFf === "sans-serif") {
             ffs.push(curFf);

--- a/src/textures/TextTextureRendererUtils.mjs
+++ b/src/textures/TextTextureRendererUtils.mjs
@@ -1,0 +1,35 @@
+/**
+ * Returns CSS font setting string for use in canvas context.
+ *
+ * @private
+ * @param {Stage} stage
+ * @param {string | string[]} fontFace
+ * @param {string} fontStyle
+ * @param {number} fontSize
+ * @param {number} precision
+ * @returns {string}
+ */
+export function getFontSetting(stage, fontFace, fontStyle, fontSize, precision) {
+    let ff = fontFace;
+
+    if (!Array.isArray(ff)) {
+        ff = [ff];
+    }
+
+    let ffs = [];
+    for (let i = 0, n = ff.length; i < n; i++) {
+        let curFf = ff[i];
+        // Replace the default font face `null` with the actual default font face set
+        // on the stage.
+        if (curFf === null) {
+            curFf = stage.getOption('defaultFontFace');
+        }
+        if (curFf === "serif" || curFf === "sans-serif") {
+            ffs.push(curFf);
+        } else {
+            ffs.push(`"${curFf}"`);
+        }
+    }
+
+    return `${fontStyle} ${fontSize * precision}px ${ffs.join(",")}`
+}


### PR DESCRIPTION
There is an inconsistency in the handling of default fonts depending on if you invoke the TextTexture renderer and call _calculateRenderInfo() directly (as I guess might be done as a pre-render measurement) or if you invoke the TextTexture normally in an attached Lightning Element via the 'text' property. 

This [Lightning playground example](https://lightningjs.io/playground/#N4IgJgpgDhB2mwMYEsIGcQC5QAEA2yA5gBYAusyshAVmgPSID2AThFiGaVGpnQ2LAB0aANYBPKAENEIwZABudfETIUqtBizYAaEMpLlKNemjAj2nbr35DRE6bIVKCBtcbqmROACyCAHIIAzCAAvrpoiMzIUKQY2CB4kgCuSMSCtFigAGbIeGyYCcmp6Ri6TJDsyAC2UCykAAQAglBQ9VnMjFX1AOSCdM1QJd0A3AA6sONMsGgNjDHIjNP1ALz1wDOShBCYawDuOwCcAGwADNr1xDsArN5n9Yh5kswAwox4LDsnAB4nv3+-IRCYyQixm9UkLRW9VgEF2TRaAAo5qQFtMAJTAsCMRBJKpwUiCABGjDAYkEEJg8GexFyYARFOEpE2EEEW1Iz0ksHkkjQCLRGJAukglIQKHQWAA2iA+gMSiAALphECyjLxHJ5dgq0ogcr5EDVWrMBoAGRUhiobQ6XW6+lURg0TFYI3G4wgX0NDUgWWSeAaDx5aHhrTdpDgYEDptcRkEAwIiEkKMWa3G9VT9Q2KMQ9QA+qGaolQ3zk7A06X6qxSElmCXgCmy-WvjsAExnOv10tiZutkvt0sAFRDO1rPd79dDX1IQ5CbdHYRnvYACqxWPAIMwh-PR6nGy3tJut8bJISIHgNyOt+3O-UAIwAdm7F9H48na3qz523SXEAAtCvIMx6koLJGG6c5gNgUgAGVkAAL22eoW2nc9HznZCLwAdWQMBSEuYtH17K8WwffCx0HV9wKg2D4MQ-dZz3NCtwACQgM0zxI+tCMCYj2LTd9yMWSi4K7JCeNQnjTRhHg8J4tNCNOeiZN4sjgDaAToKEhCThE9ixIvXStwXRgZj-Nc2PYxsrl+BT2MPY9T2kxSrzvbiZL4lS+M-IzSF-MM10A2BgNA1SIPU6itNo3t9PwzDsNw4dFNTQirIii83OCwSwu0kiosfZjWIcmTOJcni0oo0LhJS+scovCT0DMxzm3kyqn2U9Lys0rL8OqqraM6pCZ2zShkFIIt4vbHDkDQQRnwHCcqwgAARCBvSSX1A1WGE4UjO0qGmkN5qm2bSCO+aEQmqaNi2NFBAeRYIEaZhCF5NEZ36iZz2zYhOTAPIAGkIDEBFgBEAGQjRArS2QLIERBsQVmWVZumvbpwfOuRJqgRIxCOhFumYvB3nqXYWDwMAUdoqGYYB+HEabFG3xpKawAxrGcbxk9CeJ5hSYZybAMDSQ33QBpdmG4hwXqd4qD859yYYwDodhmmekCem0eZtBMckbGQ1x-HOZJsBecDPnOXqCB5DgSXFi2ADn3OXYvpFxhVqNr6WityhjfuHkIAAfjl3tKaVhHEe8NXGfRzXWd19mCcYInDe902Swtq2pdtoWJwdp3E9di4KU9ktzp9tB-fqABJAvLehBOsIgSRzjyUhRlGbpAzLiAAEJA7TV6XXPDWtZ1iczpDcGxvrPh6igVgfNXZhaKmMEgIT1ZtvNQg9rm1hDpDE7WEEEzlwRSq0cuiBrKfSOL8ELXSGA5gqlZCBSAW5hJFFqgOS5Hk+Sv3sk9HyCBAWjGa+1WBLRWmtABF4QGCCATxPgFEABi0h4LdAesgSQeBQLNV7GVKiOwuKwPYgQGEeUDDEJOPUAAVDeIIpCSLPkaC4WAH5ED4jXHg+Wj4uZgHQh-KAMUcI7COLcJhdF8FKQnDse2KVOqlmutmeMeAcQFggAAJV8swCuAVGB8gHr2ZebwWTvEILjL889-yV30UFVeL13q9jAZsSxy4dGCBEcQFG28CTPihKvQQuxaIuIsZ+dxC9BCULID458viAn6MEMQEJkcmRhK-MfQQtU0CxJDPE1YgTyHoEEHkKgOEjHjVSa47oR1ckTihIgss8CwH7wgYtZaPpYiSNTPAxp7ZkECTQZwj8WCcE8PwoQjSJD8FFOiS+LidCGGBG6aWFhbCOFcOYOMvhLABFCK8WIiRlVuqrLIvI+Wb1jGggaLUGYejgJQlCbjWp11nzzWEC7ZgnCj46PuYwFJk1prVMMsZDxXi6l+JDFCW5pA-lBIBVNNJlivKZLmRC-JM8vJwuSfLJ5nlQWROyei-xqwYVwqKVNUphBylOPbEvUEpiSmMHSV5csOjbGBXOGS-RjjSxvRCIKcA0BfJIFQHEKUtpN4Oi0AqQEugmSEjiCAHBeBQhAA) that @michielvandergeest sent me shows this inconsistency clearly. Press the 1, 2, 3, 4 keys and notice that as the text at the top changes, the measurements for pre and post render below are not the same, even though the same exact properties (both omitting `fontFace`) are passed in for both of those cases.

If the `fontFace` property is not explicitly set, the default font actually used for text rendering differs in the two cases:
- "Pre-renderer": A literal `null` is used which is automatically stringified as the font name "null", which is an invalid font name. The browser falls back to using a default font of its choosing.
- "Post-render": The value of the `defaultFontFace` Stage setting is used. Which by default is "sans-serif".

The `defaultFontFace` setting is pulled out only at the beginning of the `_getSourceLoader()` method in the TextTexture. This code, as I understand it, is not hit when using the "Pre-render" method.

The solution is the move the resolution code that converts a `null` into the Stage defined `defaultFontFace` into the method that builds the CSS font string that is passed to the Canvas2D context. This way no matter how the TextTexture is invoked/rendered it uses a consistent default.

To-Do:
- [x] Implement
- [ ] Test