### PR TITLE
TypeScript: Implement Default Loose Type Configs

### DIFF
--- a/docs/TypeScript/Components/TypeConfigs.md
+++ b/docs/TypeScript/Components/TypeConfigs.md
@@ -130,3 +130,16 @@ class MyParentComponent extends Lightning.Component {
   // ...
 }
 ```
+
+## Loose Type Configs
+
+If a Type Config is not explicitly provided, a **Loose Type Config** will be used by default. This is similar to the [**Loose Template Spec**](TemplateSpecs.md). Events and Signals will be handled in a much more looser fashion, allowing you to hook up any Events/Signals regardless of if any are explicitly specified.
+
+You can also explicitly extend the base `LooseTypeConfig` interface if you want the best of both worlds. Explicitly specified Events and Signals will be type checked. But any other Event or Signal will be allowed and be able to emit/receive `any` set of parameters.
+
+```ts
+export interface TypeConfigLoose extends Lightning.Component.TypeConfigLoose {
+  SignalMapType: MyComponentSignalMap,
+  EventMapType: MyComponentEventMap
+}
+```

--- a/src/application/Component.d.mts
+++ b/src/application/Component.d.mts
@@ -282,6 +282,12 @@ declare namespace Component {
     SignalMapType: SignalMap
   }
 
+  export interface TypeConfigLoose extends TypeConfig {
+    EventMapType: EventMap
+    SignalMapType: SignalMap
+    [s: string]: any
+  }
+
   /**
    * Augmentable interface for supplying custom key handler methods for components.
    *
@@ -380,7 +386,7 @@ interface Component extends Component.KeyHandlers {
 declare class Component<
   // Components use loose typing TemplateSpecs by default
   TemplateSpecType extends Component.TemplateSpecLoose = Component.TemplateSpecLoose,
-  TypeConfig extends Component.TypeConfig = Component.TypeConfig
+  TypeConfig extends Component.TypeConfigLoose = Component.TypeConfigLoose
 > extends Element<
   TemplateSpecType,
   TypeConfig

--- a/src/application/Component.d.mts
+++ b/src/application/Component.d.mts
@@ -445,7 +445,7 @@ declare class Component<
    */
   _captureKeyRelease?(e: KeyboardEvent): boolean | void;
 
- /**
+  /**
    * Overridable catch-all **bottom-up** _key-up_ event handler
    *
    * @remarks

--- a/src/internalTypes.d.mts
+++ b/src/internalTypes.d.mts
@@ -22,8 +22,9 @@
  * @hidden Internal use only
  * @module
  */
+import EventEmitter from './EventEmitter.mjs';
 import Component from './application/Component.mjs';
-import Element from './tree/Element.mjs'
+import Element, { IsLooseTypeConfig } from './tree/Element.mjs'
 
 /**
  * Allows all the documentation of a template spec to be inherited by any Element
@@ -76,13 +77,15 @@ export type ReduceSpecificity<T, U> =
         :
           never;
 
-
 /**
  * Extracts the EventMapType from Element Config
  *
  * @hidden Internal use only
  */
-export type EventMapType<TypeConfig extends Element.TypeConfig> = TypeConfig['EventMapType'];
+export type EventMapType<TypeConfig extends Element.TypeConfig> =
+  IsLooseTypeConfig<TypeConfig> extends true
+  ? TypeConfig['EventMapType'] & { [s: string]: (...args: any[]) => void; }
+  : TypeConfig['EventMapType']
 
 /**
  * Extracts the TextureType from Element TypeConfig
@@ -96,7 +99,10 @@ export type TextureType<TypeConfig extends Element.TypeConfig> = TypeConfig['Tex
  *
  * @hidden Internal use only
  */
-export type SignalMapType<TypeConfig extends Component.TypeConfig> = TypeConfig['SignalMapType'];
+export type SignalMapType<TypeConfig extends Component.TypeConfig> =
+  IsLooseTypeConfig<TypeConfig> extends true
+    ? TypeConfig['SignalMapType'] & { [key: string]: (...args: any[]) => any }
+    : TypeConfig['SignalMapType']
 
 /**
  * If `PossibleFunction` is a function, it returns the parameters from it as a tuple.

--- a/src/tree/Element.d.mts
+++ b/src/tree/Element.d.mts
@@ -121,6 +121,11 @@ export type TransformPossibleElement<Key, PossibleElementConstructor, Default = 
 export type IsLooseTemplateSpec<TemplateSpec extends Element.TemplateSpec> = string extends keyof TemplateSpec ? true : false;
 
 /**
+ * Returns `true` if TypeConfig is loose, `false` if it is strong
+ */
+export type IsLooseTypeConfig<TypeConfig extends Element.TypeConfig> = string extends keyof TypeConfig ? true : false;
+
+/**
  * Remove index signatures from an object
  *
  * @privateRemarks
@@ -171,8 +176,12 @@ export type RemoveIndex<T> = {
  * @hidden Internal use only
  */
 export type TemplateSpecTags<TemplateSpec extends Element.TemplateSpec> = {
-  [K in keyof CombineTagPaths<SpecToTagPaths<TemplateSpec>>]: TransformPossibleElement<K, CombineTagPaths<SpecToTagPaths<TemplateSpec>>[K]>;
-};
+  [K in keyof CombineTagPaths<SpecToTagPaths<RemoveIndex<TemplateSpec>>>]: TransformPossibleElement<K, CombineTagPaths<SpecToTagPaths<RemoveIndex<TemplateSpec>>>[K]>;
+} & (IsLooseTemplateSpec<TemplateSpec> extends true
+  ? {
+      [K in string]: any;
+    }
+  : {});
 
 /**
  * Gets an object shape containing all the Refs (child Element / Components) in a TemplateSpec
@@ -183,8 +192,12 @@ export type TemplateSpecTags<TemplateSpec extends Element.TemplateSpec> = {
  * @hidden Internal use only
  */
 export type TemplateSpecRefs<TemplateSpec extends Element.TemplateSpec> = {
-  [K in keyof CombineTagPathsSingleLevel<SpecToTagPaths<TemplateSpec>>]: TransformPossibleElement<K, CombineTagPathsSingleLevel<SpecToTagPaths<TemplateSpec>>[K]>;
-};
+  [K in keyof CombineTagPathsSingleLevel<SpecToTagPaths<RemoveIndex<TemplateSpec>>>]: TransformPossibleElement<K, CombineTagPathsSingleLevel<SpecToTagPaths<RemoveIndex<TemplateSpec>>>[K]>;
+} & (IsLooseTemplateSpec<TemplateSpec> extends true
+  ? {
+      [K in string]: any;
+    }
+  : {});
 
 //
 // Public types
@@ -1172,12 +1185,18 @@ declare namespace Element {
     TextureType: Texture,
     EventMapType: Element.EventMap
   }
+
+  export interface TypeConfigLoose extends TypeConfig {
+    TextureType: Texture
+    EventMapType: Element.EventMap
+    [s: string]: any
+  }
 }
 
 declare class Element<
   // Elements use loose typing TemplateSpecs by default (for ease of use as Elements aren't often fully definable)
   TemplateSpecType extends Element.TemplateSpecLoose = Element.TemplateSpecLoose,
-  TypeConfig extends Element.TypeConfig = Element.TypeConfig
+  TypeConfig extends Element.TypeConfigLoose = Element.TypeConfigLoose
 > extends EventEmitter<EventMapType<TypeConfig>> implements Documentation<Element.TemplateSpec> {
   constructor(stage: Stage);
 
@@ -1446,8 +1465,8 @@ declare class Element<
    * information.
    * @param tagName `.` separated tag path
    */
-  tag<Path extends keyof TemplateSpecTags<RemoveIndex<TemplateSpecType>>>(tagName: Path): TemplateSpecTags<RemoveIndex<TemplateSpecType>>[Path] | undefined;
-  tag(tagName: IsLooseTemplateSpec<TemplateSpecType> extends true ? string : never): any;
+  tag<Path extends keyof TemplateSpecTags<TemplateSpecType>>(tagName: Path): TemplateSpecTags<TemplateSpecType>[Path] | undefined;
+
   /**
    * Returns all Elements from the subtree that have this tag.
    *
@@ -1469,8 +1488,7 @@ declare class Element<
    *
    * @param ref
    */
-  getByRef<RefKey extends keyof TemplateSpecRefs<RemoveIndex<TemplateSpecType>>>(ref: RefKey): TemplateSpecRefs<RemoveIndex<TemplateSpecType>>[RefKey] | undefined;
-  getByRef(tagName: IsLooseTemplateSpec<TemplateSpecType> extends true ? string : never): any;
+  getByRef<RefKey extends keyof TemplateSpecRefs<TemplateSpecType>>(ref: RefKey): TemplateSpecRefs<TemplateSpecType>[RefKey] | undefined;
 
   /**
    * Get the location identifier of this Element

--- a/test-d/Components/Component-events.test-d.ts
+++ b/test-d/Components/Component-events.test-d.ts
@@ -333,12 +333,14 @@ namespace MyApplication_LooseTypeConfig {
   export interface TemplateSpec extends Lightning.Application.TemplateSpec {
     MyComponent1: typeof MyComponent_Strong_LooseTypeConfig;
     MyComponent2: typeof MyComponent_Strong_LooseTypeConfig;
+    MyComponent3: typeof MyComponent_Strong_LooseTypeConfig;
   }
 }
 
 class MyApplication_LooseTypeConfig extends Lightning.Application<MyApplication_LooseTypeConfig.TemplateSpec> {
   MyComponent1 = this.getByRef('MyComponent1')!;
   MyComponent2 = this.getByRef('MyComponent2')!;
+  MyComponent3 = this.tag('MyComponent3')!;
 
 
   static override _template(): Lightning.Component.Template<MyApplication_LooseTypeConfig.TemplateSpec> {
@@ -374,6 +376,20 @@ class MyApplication_LooseTypeConfig extends Lightning.Application<MyApplication_
           audit: 'handler',
           /// Should allow known signals with a boolean handler
           money: true,
+        },
+      },
+      MyComponent3: {
+        type: MyComponent_Strong_LooseTypeConfig,
+        signals: {
+          /// Should NOT allow ANY signal (known or unknown) with completely invalid types
+          // @ts-expect-error Known signal handler can't be a number
+          audit: 100,
+          // @ts-expect-error Known signal handler can't be an object
+          money: {},
+          // @ts-expect-error Unknown signal handler can't be a number
+          unknownSignal: 100,
+          // @ts-expect-error Unknown signal handler can't be an object
+          unknownSignal2: {},
         },
       },
     };

--- a/test-d/Elements/Element-Types.test-d.ts
+++ b/test-d/Elements/Element-Types.test-d.ts
@@ -324,7 +324,22 @@ function TemplateSpecTags_Test() {
 
   /// Loose template specs return empty object type
   type T2000 = TemplateSpecTags<TestTemplateSpec & lng.Component.TemplateSpecLoose>;
-  expectType<{}>({} as T2000);
+  expectType<{
+    'MyStrongElement_InlineEmpty': lng.Element<InlineElement<{}>>;
+    'MyStrongElement_InlineEmpty2': lng.Element<InlineElement<object>>;
+    'MyStrongElement_ExplicitType': lng.Element<lng.Element.TemplateSpec>;
+    'MyLooseElement': lng.Element;
+    'MyListComponent': lng.components.ListComponent;
+    'MyStrongElement_InlineChildren': lng.Element<InlineElement<TestTemplateSpec['MyStrongElement_InlineChildren']>>;
+    'MyStrongElement_InlineChildren.Child1': lng.Element<InlineElement<{}>>;
+    'MyStrongElement_InlineChildren.Child2': lng.Element<InlineElement<object>>;
+    'MyStrongElement_InlineChildren.Child3': lng.Element<lng.Element.TemplateSpec>;
+    'MyStrongElement_InlineChildren.Child4': lng.components.ListComponent;
+    'MyStrongElement_InlineChildren.Child5': lng.Element<InlineElement<TestTemplateSpec['MyStrongElement_InlineChildren']['Child5']>>;
+    'MyStrongElement_InlineChildren.Child5.GrandChild1': lng.Element<InlineElement<object>>;
+  } & {
+    [s: string]: any;
+  }>({} as T2000);
 }
 
 //

--- a/test-d/Elements/Element.test-d.ts
+++ b/test-d/Elements/Element.test-d.ts
@@ -988,6 +988,29 @@ class MyElementTest extends lng.Component<MyElementTest.TemplateSpec> implements
     expectType<typeof this.TestComponent>(this.MyStrongElement.add(this.TestComponent));
     /// If you pass an array, you get `null` back
     expectType<null>(this.MyStrongElement.add([this.MyLooseElement, this.TestComponent]));
+
+    //
+    // EventEmitter
+    //
+    // # LOOSE ONLY #
+    // Unless explicitly specified, all Elements default to having Loose Type Configs.
+    // Even if they have Strong Template Specs.
+    this.MyLooseElement.on('anythingIsAllowed', () => {});
+    this.MyStrongElement.on('anythingIsAllowed', () => {});
+    this.MyLooseElement.off('anythingIsAllowed', () => {});
+    this.MyStrongElement.off('anythingIsAllowed', () => {});
+    this.MyLooseElement.once('anythingIsAllowed', () => {});
+    this.MyStrongElement.once('anythingIsAllowed', () => {});
+    this.MyLooseElement.emit('anythingIsAllowed');
+    this.MyStrongElement.emit('anythingIsAllowed');
+    this.MyLooseElement.has('anythingIsAllowed', () => {});
+    this.MyStrongElement.has('anythingIsAllowed', () => {});
+    this.MyLooseElement.removeAllListeners('anythingIsAllowed');
+    this.MyStrongElement.removeAllListeners('anythingIsAllowed');
+    this.MyLooseElement.removeListener('anythingIsAllowed', () => {});
+    this.MyStrongElement.removeListener('anythingIsAllowed', () => {});
+    this.MyLooseElement.listenerCount('anythingIsAllowed');
+    this.MyStrongElement.listenerCount('anythingIsAllowed');
   }
 }
 

--- a/test-d/Elements/Element.test-d.ts
+++ b/test-d/Elements/Element.test-d.ts
@@ -173,7 +173,7 @@ class MyElementTest extends lng.Component<MyElementTest.TemplateSpec> implements
     >(this.tag('MyStrongElement.ChildComponent'));
 
     expectType<
-      lng.Element<InlineElement<{}>, lng.Element.TypeConfig> | undefined
+      lng.Element<InlineElement<{}>, lng.Element.TypeConfigLoose> | undefined
     >(this.tag('MyStrongElement.ChildElement'));
 
     // # LOOSE #


### PR DESCRIPTION
Lightning's type system has the concept of Loose Template Specs ([documented here](https://lightningjs.io/docs/#/lightning-core-reference/TypeScript/Components/TemplateSpecs?id=loose-components)) which allow properties and Refs that aren't actually declared in the Template Spec to be specified as if they were `any`. By default all Components that do not specify Template Spec (i.e. use the default Template Spec) use a Loose Template Spec.

Along side the Template Spec we offer another way to make Components more type strong called the [Type Config](https://lightningjs.io/docs/#/lightning-core-reference/TypeScript/Components/TypeConfigs). Unfortunately support for a Loose Type Config was not previously considered and it was brought to my attention by the Lightning UI team that this is making it difficult to use signals and events in their Component code because due to the way their classes are structured they are unable to easily pass through a Type Config.

Here I implement a Loose Type Config in much the same way that Loose Template Specs are implemented. By default Components that do not have a specified Type Config have Loose Type Configs and you are free to use any signals and events on these components. As a bonus, one can even explicitly extend the base `TypeConfigLoose` interface if they want the best of both worlds. Any event/signal is allowed and treated (essentially) as an `any`. But explicitly defined events/signals will still be type checked.

## To-do
- [x] Implementation
- [x] Basic Unit tests
- [x] Another pass on Unit Tests
- [x] Test with TMDB project
- [x] Share build with LUI team and collect feedback
- [x] Add documentation
- [x] Wait for #445 to be merged to `dev` and then rebase this PR onto `dev`.
  - **Currently the base of this PR is the `ts-fix-getbyref` branch from this PR!!**