### PR TITLE
TypeScript: Allow `id` accessor of Component to be overridden by a string accessor

### DIFF
--- a/src/tree/Element.d.mts
+++ b/src/tree/Element.d.mts
@@ -1320,7 +1320,7 @@ declare class Element<
 
   isElement: 1;
 
-  readonly id: number;
+  get id(): number | string;
 
   ref: string | undefined;
 

--- a/test-d/Components/Component.test-d.ts
+++ b/test-d/Components/Component.test-d.ts
@@ -45,3 +45,11 @@ function SpecialMethods() {
   // @ts-expect-error
   c.seekAncestorByType(Element);
 }
+
+/// Basic Component Specification Tests
+class MyComponent extends Component {
+  /// The id Component property should be overridable to return a string or a number
+  override get id(): string | number {
+    return 'MyComponent';
+  }
+}


### PR DESCRIPTION
As well as a number accessor, since by default `id` produces a number if it is not overridden.

Fixes #456