### PR TITLE
Add API doc link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -75,5 +75,6 @@ The Reference Documentation for Lightning Core contains detailed descriptions ab
     * [Subclassable Components](TypeScript/Components/SubclassableComponents.md)
   * [Guidelines / Gotchas](TypeScript/GuidelinesGotchas.md)
   * [Augmentation](TypeScript/Augmentation.md)
+* [API Docs](/api/lightning-core)
 
 <!---TOC_end--->


### PR DESCRIPTION
Add a link to the TypeDoc API documentation to the bottom of the Lightning Core TOC

## To-Do
- [ ] PR michielvandergeest/lightningjs.io#56 must be merged first
