### PR TITLE
Implement word wrapping on zero-width breaking spaces

### DIFF
--- a/docs/RenderEngine/Textures/Text.md
+++ b/docs/RenderEngine/Textures/Text.md
@@ -45,9 +45,51 @@ You can use various properties to control the way in which you want to render te
 | `letterSpacing` | Integer | 0 | Letter spacing of characters |
 
 
+## Word Wrap in Non-Latin Based Languages
 
+Enabling the `wordWrap` option causes lines of text that are too long for the
+specified `wordWrapWidth` to be broken into multiple lines. Lines are broken
+only at word boundaries. In most latin script based languages (i.e. English,
+Dutch, French, etc) the space " " character is the primary separator of word
+boundaries.
 
+Many non-latin based languages (i.e. Chinese, Japanese, Thai and more) do not use spaces
+to separate words. Instead there is an assortment of rules that determine where
+word boundaries, for the purpose of line breaking, are allowed. Lightning
+currently does not implement these rules as there are many languages and writing
+systems to consider when implementing them. However, we do offer a work around
+that can be employed in your application as needed.
 
+### Zero-Width Spaces
+
+Lightning supports line breaking at [Zero-Width Space](https://en.wikipedia.org/wiki/Zero-width_space)
+(Unicode: `\u200B`) word boundaries. These characters are like normal spaces but
+take up no actual space between visible characers. You can use them in
+your text strings and Lightning will line break on them when it needs to.
+
+You may want to write a function that you funnel all of your application's
+text strings into:
+
+```js
+function addZeroWidthSpaces(text) {
+    // Code that inserts Zero-Width Spaces into text and returns the new text
+}
+
+class ZeroWidthSpaceTextDemo extends lng.Application {
+    static _template() {
+        return {
+            Text: {
+                text: {
+                    text: addZeroWidthSpaces('こんにちは。初めまして!')
+                }
+            }
+        }
+    }
+}
+```
+
+See [this GitHub issue](https://github.com/rdkcentral/Lightning/issues/450) for
+more information.
 
 ## Live Demo
 

--- a/src/textures/TextTextureRenderer.mjs
+++ b/src/textures/TextTextureRenderer.mjs
@@ -19,7 +19,7 @@
 
 import StageUtils from "../tree/StageUtils.mjs";
 import Utils from "../tree/Utils.mjs";
-import { getFontSetting } from "./TextTextureRendererUtils.mjs";
+import { getFontSetting, isZeroWidthSpace, splitWords } from "./TextTextureRendererUtils.mjs";
 
 export default class TextTextureRenderer {
 
@@ -424,10 +424,13 @@ export default class TextTextureRenderer {
             let resultLines = [];
             let result = '';
             let spaceLeft = wordWrapWidth - indent;
-            let words = lines[i].split(' ');
-            for (let j = 0; j < words.length; j++) {
-                const wordWidth = this.measureText(words[j], letterSpacing);
-                const wordWidthWithSpace = wordWidth + this.measureText(' ',letterSpacing);
+            let words = splitWords(lines[i]);
+            for (let j = 0; j < words.length; j += 2) {
+                const space = words[j];
+                const word = words[j + 1];
+                const wordWidth = this.measureText(word, letterSpacing);
+                const spaceWidth = isZeroWidthSpace(space) ? 0 : this.measureText(space, letterSpacing);
+                const wordWidthWithSpace = wordWidth + spaceWidth;
                 if (j === 0 || wordWidthWithSpace > spaceLeft) {
                     // Skip printing the newline if it's the first word of the line that is.
                     // greater than the word wrap width.
@@ -435,12 +438,12 @@ export default class TextTextureRenderer {
                         resultLines.push(result);
                         result = '';
                     }
-                    result += words[j];
+                    result += word;
                     spaceLeft = wordWrapWidth - wordWidth - (j === 0 ? indent : 0);
                 }
                 else {
                     spaceLeft -= wordWidthWithSpace;
-                    result += ' ' + words[j];
+                    result += space + word;
                 }
             }
 

--- a/src/textures/TextTextureRendererAdvanced.mjs
+++ b/src/textures/TextTextureRendererAdvanced.mjs
@@ -19,7 +19,7 @@
 
 import StageUtils from "../tree/StageUtils.mjs";
 import Utils from "../tree/Utils.mjs";
-import { getFontSetting } from "./TextTextureRendererUtils.mjs";
+import { getFontSetting, isSpace } from "./TextTextureRendererUtils.mjs";
 
 export default class TextTextureRendererAdvanced {
 
@@ -250,7 +250,7 @@ export default class TextTextureRendererAdvanced {
             if (firstWord == '\n') {
                 l.text.shift();
             }
-            if (lastWord == ' ' || lastWord == '\n') {
+            if (isSpace(lastWord) || lastWord == '\n') {
                 l.text.pop();
             }
         }
@@ -280,7 +280,7 @@ export default class TextTextureRendererAdvanced {
 
             const spl = suffix.length + 1
             let _w = lastLineText.reduce((acc, t) => acc + t.width, 0);
-            while (_w > renderInfo.width || lastLineText[lastLineText.length - spl].text == ' ') {
+            while (_w > renderInfo.width || isSpace(lastLineText[lastLineText.length - spl].text)) {
                 lastLineText.splice(lastLineText.length - spl, 1);
                 _w = lastLineText.reduce((acc, t) => acc + t.width, 0);
                 if (lastLineText.length < spl) {
@@ -440,7 +440,7 @@ export default class TextTextureRendererAdvanced {
     }
 
     tokenize(text) {
-        const re =/ |\n|<i>|<\/i>|<b>|<\/b>|<color=0[xX][0-9a-fA-F]{8}>|<\/color>/g
+        const re =/ |\u200B|\n|<i>|<\/i>|<b>|<\/b>|<color=0[xX][0-9a-fA-F]{8}>|<\/color>/g
 
         const delimeters = text.match(re) || [];
         const words = text.split(re) || [];

--- a/src/textures/TextTextureRendererUtils.mjs
+++ b/src/textures/TextTextureRendererUtils.mjs
@@ -33,3 +33,50 @@ export function getFontSetting(fontFace, fontStyle, fontSize, precision, default
 
     return `${fontStyle} ${fontSize * precision}px ${ffs.join(",")}`
 }
+
+/**
+ * Splits a string into an array of spaces and words.
+ *
+ * @remarks
+ * This method always returns an array with an even length.
+ *
+ * - The **even indices** are the group of spaces that occur before the word at the
+ *   next (odd) index.
+ * - The **odd indices** are the words.
+ *
+ * If the string does not begin with a space, the first element of the array will
+ * be an empty string ("").
+ *
+ * @param {string} text
+ * @returns
+ */
+export function splitWords(text) {
+    const regexp = /([ \u200B]+)?([^ \u200B]+)/g;
+    const arr = [];
+    let match;
+    while ((match = regexp.exec(text)) !== null) {
+        arr.push(match[1] || '');
+        arr.push(match[2]);
+    }
+    return arr;
+}
+
+/**
+ * Returns true if the given character is a zero-width space.
+ *
+ * @param {string} space
+ * @returns {boolean}
+ */
+export function isZeroWidthSpace(space) {
+    return space === '' || space === '\u200B';
+}
+
+/**
+ * Returns true if the given character is a zero-width space or a regular space.
+ *
+ * @param {string} space
+ * @returns {boolean}
+ */
+export function isSpace(space) {
+    return isZeroWidthSpace(space) || space === ' ';
+}

--- a/src/textures/TextTextureRendererUtils.test.mjs
+++ b/src/textures/TextTextureRendererUtils.test.mjs
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getFontSetting } from './TextTextureRendererUtils.mjs';
+import { getFontSetting, splitWords, isSpace, isZeroWidthSpace } from './TextTextureRendererUtils.mjs';
 
 describe('TextTextureRendererUtils', () => {
   describe('getFontSetting', () => {
@@ -28,4 +28,52 @@ describe('TextTextureRendererUtils', () => {
       expect(getFontSetting(['serif', 'Arial', null], 'bold', 12, 1, 'Default')).toBe('bold 12px serif,"Arial","Default"');
     });
   });
+
+  describe('splitWords', () => {
+    it('should split on regular spaces', () => {
+      expect(splitWords('Hello There World')).toEqual(["", "Hello", " ", "There", " ", "World"]);
+      expect(splitWords('Hello  There   World')).toEqual(["", "Hello", "  ", "There", "   ", "World"]);
+
+    });
+    it('should split on zero-width spaces', () => {
+      expect(splitWords('Hello\u200BThere\u200BWorld')).toEqual(["", "Hello", "\u200B", "There", "\u200B", "World"]);
+      expect(splitWords('Hello\u200B\u200BThere\u200B\u200B\u200BWorld')).toEqual(["", "Hello", "\u200B\u200B", "There", "\u200B\u200B\u200B", "World"]);
+    });
+    it('should split on a combo of spaces and zero-width spaces', () => {
+      expect(splitWords('Hello\u200B There \u200B World')).toEqual(["", "Hello", "\u200B ", "There", " \u200B ", "World"]);
+    });
+    it('should capture the first group of spaces if the string begins with spaces', () => {
+      expect(splitWords(' Hello There World')).toEqual([" ", "Hello", " ", "There", " ", "World"]);
+      expect(splitWords(' \u200BHello There World')).toEqual([" \u200B", "Hello", " ", "There", " ", "World"]);
+    });
+  });
+
+  describe('isZeroWidthSpace', () => {
+    it('should return true for empty string', () => {
+      expect(isZeroWidthSpace('')).toBe(true);
+    });
+    it('should return true for zero-width space', () => {
+      expect(isZeroWidthSpace('\u200B')).toBe(true);
+    });
+    it('should return false for non-zero-width space', () => {
+      expect(isZeroWidthSpace(' ')).toBe(false);
+      expect(isZeroWidthSpace('a')).toBe(false);
+    });
+  });
+
+  describe('isSpace', () => {
+    it('should return true for empty string', () => {
+      expect(isSpace('')).toBe(true);
+    });
+    it('should return true for zero-width space', () => {
+      expect(isSpace('\u200B')).toBe(true);
+    });
+    it('should return true for regular space', () => {
+      expect(isSpace(' ')).toBe(true);
+    });
+    it('should return false for non-space', () => {
+      expect(isSpace('a')).toBe(false);
+    });
+  });
+
 });


### PR DESCRIPTION
This PR enables word wrapping to occur on the zero-width space character `0x200B` ([Unicode Explorer](https://unicode-explorer.com/c/200B), [Wikipedia](https://en.wikipedia.org/wiki/Zero-width_space#:~:text=The%20zero%2Dwidth%20space%20character,%3B%20or%20%E2%80%8B%20.)). This enables developers to programmatically insert these characters in appropriate places for writing systems that do not use space characters to separate words without negatively affecting how the text renders when it is not word wrapped.

This feature has been implemented in both the standard TextTextureRenderer as well as TextTextureRendererAdvanced. However, I noticed that there seem to be unrelated vertical spacing issues with rendering non-Latin script like Chinese that are out of the scope of this feature.

Fixes https://github.com/rdkcentral/Lightning/issues/450 (or at least enables developers to work around the problem)