### PR TITLE
Add named export for Lightning in the ESM build

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,17 +4,17 @@
   "version": "2.10.0",
   "license": "Apache-2.0",
   "type": "module",
-  "types": "dist/index.d.ts",
+  "types": "dist/src/lightning.esm.d.mts",
   "module": "dist/lightning.esm.js",
   "main": "dist/lightning.js",
   "exports": {
     ".": {
       "import": {
-        "types": "./dist/index.d.ts",
+        "types": "./dist/src/lightning.esm.d.mts",
         "default": "./dist/lightning.esm.js"
       },
       "require": {
-        "types": "./dist/index.d.ts",
+        "types": "./dist/src/lightning.d.mts",
         "default": "./dist/lightning.js"
       }
     },

--- a/src/lightning.esm.d.mts
+++ b/src/lightning.esm.d.mts
@@ -1,0 +1,27 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2023 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Special entrypoint for the ESM build that exports Lightning as both
+ * a default and named export.
+ * @module
+ */
+import Lightning from './lightning.mjs';
+
+export default Lightning;
+export { Lightning };

--- a/src/lightning.esm.mjs
+++ b/src/lightning.esm.mjs
@@ -1,0 +1,27 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2023 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Special entrypoint for the ESM build that exports Lightning as both
+ * a default and named export.
+ * @module
+ */
+import Lightning from './lightning.mjs';
+
+export default Lightning;
+export { Lightning };

--- a/vite.config.js
+++ b/vite.config.js
@@ -15,7 +15,7 @@ const isMinifiedBuild = process.env.BUILD_MINIFY === 'true';
 const isInspectorBuild = process.env.BUILD_INSPECTOR === 'true';
 
 let outDir = 'dist';
-let entry = resolve(__dirname, 'src/lightning.mjs');
+let entry = resolve(__dirname, isEs5Build ? 'src/lightning.mjs' : 'src/lightning.esm.mjs');
 let outputBase = 'lightning';
 let sourcemap = true;
 let useDts = true;


### PR DESCRIPTION
Also have package.json point directly to the entry point `.d.mts` type definition files. Previously it pointed to `index.d.ts`/`index.js` which as far as I'm aware now isn't used as all as an entry point for the bundler nor is it exported in package.json. I think we might be able to delete those files, though its possible they are used in some way I'm not aware of.

Fixes #480