### PR TITLE
TextTextureRenderer: Fix word wrap behavior that regressed in 2.10.0

### DIFF
--- a/src/textures/TextTextureRendererUtils.mjs
+++ b/src/textures/TextTextureRendererUtils.mjs
@@ -35,33 +35,6 @@ export function getFontSetting(fontFace, fontStyle, fontSize, precision, default
 }
 
 /**
- * Splits a string into an array of spaces and words.
- *
- * @remarks
- * This method always returns an array with an even length.
- *
- * - The **even indices** are the group of spaces that occur before the word at the
- *   next (odd) index.
- * - The **odd indices** are the words.
- *
- * If the string does not begin with a space, the first element of the array will
- * be an empty string ("").
- *
- * @param {string} text
- * @returns
- */
-export function splitWords(text) {
-    const regexp = /([ \u200B]+)?([^ \u200B]+)/g;
-    const arr = [];
-    let match;
-    while ((match = regexp.exec(text)) !== null) {
-        arr.push(match[1] || '');
-        arr.push(match[2]);
-    }
-    return arr;
-}
-
-/**
  * Returns true if the given character is a zero-width space.
  *
  * @param {string} space
@@ -79,4 +52,104 @@ export function isZeroWidthSpace(space) {
  */
 export function isSpace(space) {
     return isZeroWidthSpace(space) || space === ' ';
+}
+
+/**
+ * Converts a string into an array of tokens and the words between them.
+ *
+ * @param {RegExp} tokenRegex
+ * @param {string} text
+ * @returns {string[]}
+ */
+export function tokenizeString(tokenRegex, text) {
+    const delimeters = text.match(tokenRegex) || [];
+    const words = text.split(tokenRegex) || [];
+
+    let final = [];
+    for (let i = 0; i < words.length; i++) {
+        final.push(words[i], delimeters[i])
+    }
+    final.pop()
+    return final.filter((word) => word != '');
+}
+
+/**
+ * Measure the width of a string accounting for letter spacing.
+ *
+ * @param {CanvasRenderingContext2D} context
+ * @param {string} word
+ * @param {number} space
+ * @returns
+ */
+export function measureText(context, word, space = 0) {
+    if (!space) {
+        return context.measureText(word).width;
+    }
+    return word.split('').reduce((acc, char) => {
+        // Zero-width spaces should not include letter spacing.
+        // And since we know the width of a zero-width space is 0, we can skip
+        // measuring it.
+        if (isZeroWidthSpace(char)) {
+            return acc;
+        }
+        return acc + context.measureText(char).width + space;
+    }, 0);
+}
+
+/**
+ * Applies newlines to a string to have it optimally fit into the horizontal
+ * bounds set by the Text object's wordWrapWidth property.
+ *
+ * @param {CanvasRenderingContext2D} context
+ * @param {string} text
+ * @param {number} wordWrapWidth
+ * @param {number} letterSpacing
+ * @param {number} indent
+ * @returns
+ */
+export function wrapText(context, text, wordWrapWidth, letterSpacing, indent) {
+    // Greedy wrapping algorithm that will wrap words as the line grows longer.
+    // than its horizontal bounds.
+    const spaceRegex = / |\u200B/g;
+    let lines = text.split(/\r?\n/g);
+    let allLines = [];
+    let realNewlines = [];
+    for (let i = 0; i < lines.length; i++) {
+        let resultLines = [];
+        let result = '';
+        let spaceLeft = wordWrapWidth - indent;
+        let words = lines[i].split(spaceRegex);
+        let spaces = lines[i].match(spaceRegex) || [];
+        for (let j = 0; j < words.length; j++) {
+            const space = spaces[j - 1] || '';
+            const word = words[j];
+            const wordWidth = measureText(context, word, letterSpacing);
+            const wordWidthWithSpace = wordWidth + measureText(context, space, letterSpacing);
+            if (j === 0 || wordWidthWithSpace > spaceLeft) {
+                // Skip printing the newline if it's the first word of the line that is.
+                // greater than the word wrap width.
+                if (j > 0) {
+                    resultLines.push(result);
+                    result = '';
+                }
+                result += word;
+                spaceLeft = wordWrapWidth - wordWidth - (j === 0 ? indent : 0);
+            }
+            else {
+                spaceLeft -= wordWidthWithSpace;
+                result += space + word;
+            }
+        }
+
+        resultLines.push(result);
+        result = '';
+
+        allLines = allLines.concat(resultLines);
+
+        if (i < lines.length - 1) {
+            realNewlines.push(allLines.length);
+        }
+    }
+
+    return {l: allLines, n: realNewlines};
 }

--- a/src/textures/TextTextureRendererUtils.test.mjs
+++ b/src/textures/TextTextureRendererUtils.test.mjs
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getFontSetting, splitWords, isSpace, isZeroWidthSpace } from './TextTextureRendererUtils.mjs';
+import { getFontSetting, tokenizeString, isSpace, isZeroWidthSpace, wrapText, measureText } from './TextTextureRendererUtils.mjs';
 
 describe('TextTextureRendererUtils', () => {
   describe('getFontSetting', () => {
@@ -29,25 +29,6 @@ describe('TextTextureRendererUtils', () => {
     });
   });
 
-  describe('splitWords', () => {
-    it('should split on regular spaces', () => {
-      expect(splitWords('Hello There World')).toEqual(["", "Hello", " ", "There", " ", "World"]);
-      expect(splitWords('Hello  There   World')).toEqual(["", "Hello", "  ", "There", "   ", "World"]);
-
-    });
-    it('should split on zero-width spaces', () => {
-      expect(splitWords('Hello\u200BThere\u200BWorld')).toEqual(["", "Hello", "\u200B", "There", "\u200B", "World"]);
-      expect(splitWords('Hello\u200B\u200BThere\u200B\u200B\u200BWorld')).toEqual(["", "Hello", "\u200B\u200B", "There", "\u200B\u200B\u200B", "World"]);
-    });
-    it('should split on a combo of spaces and zero-width spaces', () => {
-      expect(splitWords('Hello\u200B There \u200B World')).toEqual(["", "Hello", "\u200B ", "There", " \u200B ", "World"]);
-    });
-    it('should capture the first group of spaces if the string begins with spaces', () => {
-      expect(splitWords(' Hello There World')).toEqual([" ", "Hello", " ", "There", " ", "World"]);
-      expect(splitWords(' \u200BHello There World')).toEqual([" \u200B", "Hello", " ", "There", " ", "World"]);
-    });
-  });
-
   describe('isZeroWidthSpace', () => {
     it('should return true for empty string', () => {
       expect(isZeroWidthSpace('')).toBe(true);
@@ -73,6 +54,217 @@ describe('TextTextureRendererUtils', () => {
     });
     it('should return false for non-space', () => {
       expect(isSpace('a')).toBe(false);
+    });
+  });
+
+  describe('tokenizeString', () => {
+    it('should split text into an array of specific tokens', () => {
+      const tokenRegex = / +|\n|<b>|<\/b>/g;
+      expect(tokenizeString(tokenRegex, "Hello <b>there</b>  world.\n")).toEqual(['Hello', ' ', '<b>', 'there', '</b>', '  ', 'world.', '\n']);
+    })
+  });
+
+  /**
+   * Mock context for testing measureText / wrapText
+   */
+  const contextMock = {
+    measureText: (text) => {
+      return {
+        width: text.split('').reduce((acc, char) => {
+          if (!isZeroWidthSpace(char)) {
+            acc += 10;
+          }
+          return acc;
+        }, 0)
+      }
+    }
+  }
+
+  describe('measureText', () => {
+    it('should return 0 for an empty string', () => {
+      expect(measureText(contextMock, '', 0)).toBe(0);
+      expect(measureText(contextMock, '', 10)).toBe(0);
+    });
+
+    it('should return the width of a string', () => {
+      expect(measureText(contextMock, 'abc', 0)).toBe(30);
+      expect(measureText(contextMock, 'a b c', 0)).toBe(50);
+    });
+
+    it('should return the width of a string with letter spacing', () => {
+      expect(measureText(contextMock, 'abc', 1)).toBe(33);
+      expect(measureText(contextMock, 'a b c', 1)).toBe(55);
+    });
+
+    it('should not add letter spacing to zero-width spaces', () => {
+      expect(measureText(contextMock, '\u200B', 1)).toBe(0);
+      expect(measureText(contextMock, '\u200B\u200B', 1)).toBe(0);
+      expect(measureText(contextMock, 'a\u200Bb\u200Bc', 1)).toBe(33);
+    });
+  });
+
+  describe('wrapText', () => {
+    it('should not break up text if it fits', () => {
+      // No indent / no letter spacing
+      expect(wrapText(contextMock, 'Hello World', 110, 0, 0)).to.deep.equal({
+        l: ['Hello World'],
+        n: []
+      });
+      // With indent
+      expect(wrapText(contextMock, 'Hello World', 110 + 10, 0, 10)).to.deep.equal({
+        l: ['Hello World'],
+        n: []
+      });
+      // With letter spacing
+      expect(wrapText(contextMock, 'Hello World', 110 + 11, 1, 0)).to.deep.equal({
+        l: ['Hello World'],
+        n: []
+      });
+    });
+    it('should break up text if it doesn\'t fit on one line (1 pixel edge case)', () => {
+      // No indent / no letter spacing
+      expect(wrapText(contextMock, 'Hello World', 110 - 1 /* 1 less */, 0, 0)).to.deep.equal({
+        l: ['Hello', 'World'],
+        n: []
+      });
+      // With indent
+      expect(wrapText(contextMock, 'Hello World', 110 + 10 - 1 /* 1 less */, 0, 10)).to.deep.equal({
+        l: ['Hello', 'World'],
+        n: []
+      });
+      // With letter spacing
+      expect(wrapText(contextMock, 'Hello World', 110 + 11 - 1 /* 1 less */, 1, 0)).to.deep.equal({
+        l: ['Hello', 'World'],
+        n: []
+      });
+    });
+    it('should produce indexes to real line breaks', () => {
+      expect(wrapText(contextMock, 'Hello World', 50, 0, 0)).to.deep.equal({
+        l: ['Hello', 'World'],
+        n: []
+      });
+
+      expect(wrapText(contextMock, 'Hello\nWorld', 50, 0, 0)).to.deep.equal({
+        l: ['Hello', 'World'],
+        n: [1]
+      });
+
+      expect(wrapText(contextMock, 'Hello There\nWorld', 50, 0, 0)).to.deep.equal({
+        l: ['Hello', 'There', 'World'],
+        n: [2]
+      });
+
+      expect(wrapText(contextMock, 'Hello\nThere\nWorld', 50, 0, 0)).to.deep.equal({
+        l: ['Hello', 'There', 'World'],
+        n: [1, 2]
+      });
+    });
+
+    it('should make the first line an empty string if the first character is a space or a line break', () => {
+      expect(wrapText(contextMock, '\nHello\nThere\nWorld', 50, 0, 0)).to.deep.equal({
+        l: ['', 'Hello', 'There', 'World'],
+        n: [1, 2, 3]
+      });
+
+      expect(wrapText(contextMock, ' Hello\nThere\nWorld', 50, 0, 0)).to.deep.equal({
+        l: ['', 'Hello', 'There', 'World'],
+        n: [2, 3]
+      });
+    });
+
+    it('should REMOVE one of the spaces in a sequence of spaces if a line is broken across it', () => {
+      // Left
+      expect(wrapText(contextMock, ' Hello', 50, 0, 0)).to.deep.equal({
+        l: ['', 'Hello'],
+        n: []
+      });
+
+      expect(wrapText(contextMock, '  Hello', 50, 0, 0)).to.deep.equal({
+        l: [' ', 'Hello'],
+        n: []
+      });
+
+      // Middle
+      expect(wrapText(contextMock, 'Hello World', 50, 0, 0)).to.deep.equal({
+        l: ['Hello', 'World'],
+        n: []
+      });
+
+      expect(wrapText(contextMock, 'Hello  World', 50, 0, 0)).to.deep.equal({
+        l: ['Hello', '', 'World'], // Since ther are two breaks 2 spaces are removed
+        n: []
+      });
+
+      expect(wrapText(contextMock, 'Hello   World', 50, 0, 0)).to.deep.equal({
+        l: ['Hello', ' ', 'World'], // Since ther are two breaks 2 spaces are removed
+        n: []
+      });
+
+      // Right
+      expect(wrapText(contextMock, 'World ', 50, 0, 0)).to.deep.equal({
+        l: ['World', ''],
+        n: []
+      });
+
+      expect(wrapText(contextMock, 'World  ', 50, 0, 0)).to.deep.equal({
+        l: ['World', ' '],
+        n: []
+      });
+    });
+
+    it('should break up a single line of text into many lines based on varying wrapWidth, letterSpacing and indent', () => {
+      // No indent / no letter spacing
+      expect(wrapText(contextMock, "     Let's     start     Building!           ", 160, 0, 0)).to.deep.equal({
+        l: [ "     Let's    ", 'start    ', 'Building!       ', '   ' ],
+        n: []
+      });
+      expect(wrapText(contextMock, "     Let's     start     Building!           ", 120, 0, 0)).to.deep.equal({
+        l: [ "     Let's  ", "  start    ", "Building!   ", "       " ],
+        n: []
+      });
+      expect(wrapText(contextMock, "     Let's     start     Building!           ", 80, 0, 0)).to.deep.equal({
+        l: [ "    ", "Let's   ", " start  ", " ", "Building!", "        ", " " ],
+        n: []
+      });
+      // With indent
+      expect(wrapText(contextMock, "    Let's     start     Building!           ", 160, 0, 10)).to.deep.equal({
+        l: [ "    Let's    ", "start    ", "Building!       ", "   " ],
+        n: []
+      });
+      expect(wrapText(contextMock, "   Let's     start     Building!           ", 160, 0, 20)).to.deep.equal({
+        l: [ "   Let's    ", "start    ", "Building!       ", "   " ],
+        n: []
+      });
+      expect(wrapText(contextMock, "  Let's     start     Building!           ", 160, 0, 30)).to.deep.equal({
+        l: [ "  Let's    ", "start    ", "Building!       ", "   " ],
+        n: []
+      });
+      // With letter spacing
+      expect(wrapText(contextMock, "     Let's     start     Building!           ", 160, 1, 0)).to.deep.equal({
+        l: [ "     Let's    ", "start    ", "Building!     ", "     " ],
+        n: []
+      });
+      expect(wrapText(contextMock, "     Let's     start     Building!           ", 160, 5, 0)).to.deep.equal({
+        l: [ "     Let's", "    start ", "  ", "Building! ", "         " ],
+        n: []
+      });
+    });
+
+    it('should support wrapping on zero-width spaces', () => {
+      expect(wrapText(contextMock, 'H\u200Be\u200Bl\u200Bl\u200Bo\u200BW\u200Bo\u200Br\u200Bl\u200Bd', 10, 0, 0)).to.deep.equal({
+        l: ['H', 'e', 'l', 'l', 'o', 'W', 'o', 'r', 'l' , 'd'],
+        n: []
+      });
+
+      expect(wrapText(contextMock, 'H\u200Be\u200Bl\u200Bl\u200Bo\u200BW\u200Bo\u200Br\u200Bl\u200Bd', 20, 0, 0)).to.deep.equal({
+        l: ['H\u200Be', 'l\u200Bl', 'o\u200BW', 'o\u200Br', 'l\u200Bd'],
+        n: []
+      });
+
+      expect(wrapText(contextMock, 'H\u200Be\u200Bl\u200Bl\u200Bo\u200BW\u200Bo\u200Br\u200Bl\u200Bd', 50, 0, 0)).to.deep.equal({
+        l: ['H\u200Be\u200Bl\u200Bl\u200Bo', 'W\u200Bo\u200Br\u200Bl\u200Bd'],
+        n: []
+      });
     });
   });
 


### PR DESCRIPTION
Behavior has been reverted back to pre-2.10.0 behavior while retaining the zero-width space functionality.

- Moves `textWrap()` and `measureText()` methods to TextRendererUtils
  - Tests for both with the ability to mock up the C2D context version of measureText()
  - All direct context calls to measure text have been changed to use the util method.
  - The unit tests for `textWrap()` were originally written to pass for the original implementation prior to adding back the zero-width space functionality (plus a test for that)
- Removes `splitWords()`
- Moves `tokenize()` implementation for advanced renderer to TextRendererUtils w/ unit test

## Todo

- [x] Implement
- [x] Unit tests
- [x] Integration test

## Fixes
- #488