### PR TITLE
Remove unnecessary conditional

### DIFF
--- a/src/renderer/webgl/shaders/DefaultShader.mjs
+++ b/src/renderer/webgl/shaders/DefaultShader.mjs
@@ -74,10 +74,9 @@ export default class DefaultShader extends WebGLShader {
                     pos = i;
                 }
             }
-            if (pos < length) {
-                gl.bindTexture(gl.TEXTURE_2D, glTexture);
-                gl.drawElements(gl.TRIANGLES, 6 * (length - pos), gl.UNSIGNED_SHORT, (pos + operation.index) * 6 * 2);
-            }
+            
+            gl.bindTexture(gl.TEXTURE_2D, glTexture);
+            gl.drawElements(gl.TRIANGLES, 6 * (length - pos), gl.UNSIGNED_SHORT, (pos + operation.index) * 6 * 2);
         }
     }
 


### PR DESCRIPTION
The conditional is provable `if (true)`.

`pos` starts at 0, and only increments in the for loop below bounded in iterations by `length`.

Therefore, pos can never be greater than length.