### PR TITLE
Fix texture changed logic

### DIFF
--- a/src/tree/Element.mjs
+++ b/src/tree/Element.mjs
@@ -606,7 +606,7 @@ export default class Element {
             }
         }
 
-        const prevSource = this.__core.displayedTextureSource ? this.__core.displayedTextureSource._source : null;
+        const prevSource = this.__core.displayedTextureSource;
         const sourceChanged = (v ? v._source : null) !== prevSource;
 
         this.__displayedTexture = v;


### PR DESCRIPTION
It looks like there has been (forever) a bug in the elements' `txLoaded` event, over-firing because it incorrectly identifies texture changes.

`this.__core.displayedTextureSource` is a `TextureSource` but was apparently used in the code as if it was a `Texture` (thank you untyped JS).