### PR TITLE
Fix SVG txError not triggering

### DIFF
--- a/src/tools/Tools.mjs
+++ b/src/tools/Tools.mjs
@@ -170,7 +170,7 @@ export default class Tools {
             ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
             cb(null, canvas);
         }
-        img.onError = (err) => {
+        img.onerror = (err) => {
             cb(err);
         }
 


### PR DESCRIPTION
Currently, SVG txError events are not triggered due to errors not getting captured. This change correctly handles the onerror event, which subsequently triggers the txError correctly.