### PR TITLE
fix: RoundedRectangleShader clipping stroke

### DIFF
--- a/src/renderer/webgl/shaders/RoundedRectangleShader.mjs
+++ b/src/renderer/webgl/shaders/RoundedRectangleShader.mjs
@@ -35,6 +35,10 @@ export default class RoundedRectangleShader extends DefaultShader {
         this._blend = Math.min(Math.max(p, 0), 1);
     }
 
+    get blend() {
+        return this._blend;
+    }
+
     set radius(v) {
         if(Array.isArray(v)) {
             if(v.length === 2) {
@@ -93,7 +97,7 @@ export default class RoundedRectangleShader extends DefaultShader {
     }
 
     get bottomLeft() {
-        return this._radius[4];
+        return this._radius[3];
     }
 
     set strokeColor(argb) {
@@ -229,6 +233,6 @@ RoundedRectangleShader.fragmentShaderSource = `
         vec4 tex = texture2D(uSampler, vTextureCoord) * vColor;
         vec4 blend = mix(vec4(1.0) * alpha, tex, blend);     
         vec4 layer1 = mix(vec4(0.0), tex * fillColor, fillMask(b));
-        gl_FragColor = mix(layer1, blend * strokeColor, innerBorderMask(b, stroke));
+        gl_FragColor = mix(layer1, blend * strokeColor, innerBorderMask(b + 1.0, stroke));
     }
 `;


### PR DESCRIPTION
At it's current state, when setting a value for stroke on the RoundedRectangleShader the stroke itself gets clipped incorrectly.
This is more noticiable when you put the radius at half the height (on a square) to make it a circle and then you can see it clipping the top/bottom and left/right of the stroke.

![Comparative](https://github.com/rdkcentral/Lightning/assets/96475496/8fd3a330-0e1a-4452-8de2-080731fc9c23)

Round:
<img width="439" alt="Screenshot 2024-01-11 at 21 16 40" src="https://github.com/rdkcentral/Lightning/assets/96475496/e6419c1f-ad52-4d56-b858-f25cae740a11">
vs
<img width="426" alt="image" src="https://github.com/rdkcentral/Lightning/assets/96475496/a2965fd8-80fc-424a-8ae6-76b39c66213f">

Rectangle:
<img width="595" alt="image" src="https://github.com/rdkcentral/Lightning/assets/96475496/615d020f-1ec1-4578-927c-964ed6e49fcc">
vs
<img width="627" alt="image" src="https://github.com/rdkcentral/Lightning/assets/96475496/cf7d4d91-dee6-4827-834b-c272e92bd90a">
