### PR TITLE
Hotfix - properly publishing typescript types.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.13.1
+*12 apr 2024*
+
+- Hotfix - Typescript types were not properly published
+
 ## v2.13.0
 *11 apr 2024*
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lightningjs/core",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lightningjs/core",
-      "version": "2.13.0",
+      "version": "2.13.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "^7.8.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": "Metrological, Bas van Meurs <b.van.meurs@metrological.com>",
   "name": "@lightningjs/core",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "license": "Apache-2.0",
   "type": "module",
   "types": "dist/src/index.d.ts",


### PR DESCRIPTION
During publish of the package the Typescript definition files weren't properly built.

Ran a new release and tagged it as 2.13.1