### PR TITLE
Fix - Don't GC when releasing memory

### DIFF
--- a/src/tree/Stage.mjs
+++ b/src/tree/Stage.mjs
@@ -449,7 +449,7 @@ export default class Stage extends EventEmitter {
 
     addMemoryUsage(delta) {
         this._usedMemory += delta;
-        if (this._lastGcFrame !== this.frameCounter) {
+        if (delta > 0 && this._lastGcFrame !== this.frameCounter) {
             if (this._usedMemory > this.getOption('memoryPressure')) {
                 this.gc(false);
                 if (this._usedMemory > this.getOption('memoryPressure') - 2e6) {


### PR DESCRIPTION
When memory is released, calling `Stage.addMemoryUsage` with a negative `delta`, we should never trigger a `gc`.

Fixes #529 