### PR TITLE
Release - v2.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v2.13.2
+*04 June 2024*
+
+- Fixes limiting behaviour that prevented using other system fonts. (#537)
+- Fixes duplicated call for `_cleanupLookupMap()` in the garbage collection function. (#520)
+- Fixes the issue causing double freeing of textures due to the garbage collection triggered during releasing memory. (#529)
+
 ## v2.13.1
 *12 apr 2024*
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lightningjs/core",
-  "version": "2.13.1",
+  "version": "2.13.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lightningjs/core",
-      "version": "2.13.1",
+      "version": "2.13.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "^7.8.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": "Metrological, Bas van Meurs <b.van.meurs@metrological.com>",
   "name": "@lightningjs/core",
-  "version": "2.13.1",
+  "version": "2.13.2",
   "license": "Apache-2.0",
   "type": "module",
   "types": "dist/src/index.d.ts",

--- a/src/textures/TextTextureRendererUtils.mts
+++ b/src/textures/TextTextureRendererUtils.mts
@@ -45,10 +45,10 @@ export function getFontSetting(
         let curFf = ff[i];
         // Replace the default font face `null` with the actual default font face set
         // on the stage.
-        if (curFf === null) {
+        if (curFf == null) {
             curFf = defaultFontFace;
         }
-        if (curFf === "serif" || curFf === "sans-serif") {
+        if (curFf.indexOf(' ') < 0) {
             ffs.push(curFf);
         } else {
             ffs.push(`"${curFf}"`);

--- a/src/tree/Stage.mjs
+++ b/src/tree/Stage.mjs
@@ -449,7 +449,7 @@ export default class Stage extends EventEmitter {
 
     addMemoryUsage(delta) {
         this._usedMemory += delta;
-        if (this._lastGcFrame !== this.frameCounter) {
+        if (delta > 0 && this._lastGcFrame !== this.frameCounter) {
             if (this._usedMemory > this.getOption('memoryPressure')) {
                 this.gc(false);
                 if (this._usedMemory > this.getOption('memoryPressure') - 2e6) {

--- a/src/tree/TextureManager.mjs
+++ b/src/tree/TextureManager.mjs
@@ -139,7 +139,6 @@ export default class TextureManager {
 
     gc() {
         this.freeUnusedTextureSources();
-        this._cleanupLookupMap();
     }
     
     freeUnusedTextureSources() {


### PR DESCRIPTION
## Changes

- Fixes limiting behaviour that prevented using other system fonts. (#537)
- Fixes duplicated call for `_cleanupLookupMap()` in the garbage collection function. (#520)
- Fixes the issue causing double freeing of textures due to the garbage collection triggered during releasing memory. (#529)

#### Issues Fixed

- #537
- #520 
- #529 

#### PRs Included

- #532    
- #535 
- #538 
- #539 

#### Todo

- [x] Update `package.json` and `package-lock.json`
- [x] Update `CHANGELOG.md`
