### PR TITLE
fix: Reset onIdle on every RAF subloop

### DIFF
--- a/src/platforms/browser/WebPlatform.mjs
+++ b/src/platforms/browser/WebPlatform.mjs
@@ -101,12 +101,10 @@ export default class WebPlatform {
     }
 
     loop() {
-        // reset idle state
-        this._onIdle = false;
-
         let self = this;
         let lp = function () {
             self._awaitingLoop = false;
+            self._onIdle = false;
             if (self._looping) {
                 self.stage.updateFrame();
                 if (self.stage.getOption("pauseRafLoopOnIdle")) {


### PR DESCRIPTION
Moving onIdle reset, it wasn't clearing it consistently due to rafloop and start / stop loop sequence.