### PR TITLE
fix(Element): use similar types for displayed texture source comparison

### DIFF
--- a/src/tree/Element.mjs
+++ b/src/tree/Element.mjs
@@ -606,7 +606,7 @@ export default class Element {
             }
         }
 
-        const prevSource = this.__core.displayedTextureSource;
+        const prevSource = this.__core.displayedTextureSource ? this.__core.displayedTextureSource._source : null;
         const sourceChanged = (v ? v._source : null) !== prevSource;
 
         this.__displayedTexture = v;


### PR DESCRIPTION
The change introduced in #508 seems to be comparing incompatible types, which is causing an issue where patching in a new texture source is the only thing that triggers a `txLoaded` event to fire; patching new dimensions does not fire that event.

The issue can be seen here: https://playground.lightningjs.io/#Mhe2FycwzpSt

This fix reverts the check to a previous version where patching in dimensions constitutes as a new texture having loaded, which will fire off the appropriate event.