### PR TITLE
Feature - animation by ref

### DIFF
--- a/docs/Animations/Actions.md
+++ b/docs/Animations/Actions.md
@@ -7,7 +7,7 @@ The actions of an animation define what happens with the specified views and pro
 
 | Name | Type | Default | Description | Values |
 |---|---|---|---|---|
-| `t` | String | none | Tag selector (see View.tag function) on which the animation must be applied | SomeTag,SomeTag.SomeSubTag |
+| `t` | String, Element | none | Either a tag selector (see View.tag function), or an Element reference, on which the animation must be applied | "SomeTag", "SomeTag.SomeSubTag" |
 | `p` | Property | none | Object property you want to animate | x, y, w, h, alpha, rotation, scale, texture.x, shader.someProp |
 | `v` | Object | {} | Definition of time-value function | See description |
 | `rv` | * | none | After stopping, the defined value `v` at progress 0 is used. If another value is desired, `rv` can be used. |  |

--- a/src/animation/AnimationActionSettings.d.mts
+++ b/src/animation/AnimationActionSettings.d.mts
@@ -141,7 +141,7 @@ declare namespace AnimationActionSettings {
    * for more information.
    */
   export interface Literal<Key, ValueType extends AnimatableValueTypes> {
-    // selector?: string;
+    // selector?: string | Element;
     // - Removed for same reasons as `properties` below
 
     /**
@@ -152,15 +152,13 @@ declare namespace AnimationActionSettings {
      *   - The child Elements (of the Element you're calling {@link Element.animation} on) that
      *     match the selector string will be animated.
      * - Otherwise:
-     *   - The Element you are calling `animation()` on will be animated.
+     *   - The Element (or object) you are calling `animation()` on will be animated.
      *
      * WARNING: Because it's impossible to make tag selection type-safe it is recommended
-     * you do not use `t` when using TypeScript. Instead, call `animation()` directly on
+     * to use a reference when using TypeScript, or call `animation()` directly on
      * each Element you wish to animate.
-     *
-     * @deprecated See note about type-safety in the Remarks section.
      */
-    t?: string;
+    t?: string | Element;
 
     // properties?: Key | Array<Key>;
     // - Removed because its duplicative and potentially error prone

--- a/src/animation/AnimationActionSettings.mjs
+++ b/src/animation/AnimationActionSettings.mjs
@@ -24,8 +24,8 @@ export default class AnimationActionSettings {
         this.animationSettings = animationSettings;
 
         /**
-         * The selector that selects the elements.
-         * @type {string}
+         * The selector that selects the elements, or the element itself.
+         * @type {string | object}
          */
         this._selector = "";
 
@@ -96,7 +96,12 @@ export default class AnimationActionSettings {
     }
     
     getAnimatedElements(element) {
-        return element.select(this._selector);
+        const selector = this._selector;
+        if (typeof selector === 'string') {
+            return element.select(selector);
+        } else {
+            return [selector];
+        }
     }
 
     reset(element) {

--- a/src/animation/AnimationActionSettings.test.mjs
+++ b/src/animation/AnimationActionSettings.test.mjs
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from 'vitest';
+import AnimationActionSettings from './AnimationActionSettings.mjs';
+
+describe('AnimationActionSettings', () => {
+  it('resolves selector path', () => {
+    const mockResult = [{}];
+    const mockElement = {
+      select: vi.fn().mockImplementation(() => mockResult)
+    };
+
+    const aas = new AnimationActionSettings();
+    aas.t = 'some.path';
+
+    const actual = aas.getAnimatedElements(mockElement);
+
+    expect(mockElement.select).toHaveBeenCalledWith('some.path');
+    expect(actual).toBe(mockResult);
+  });
+
+  it('acceptes selector by reference', () => {
+    const mockTarget = {};
+    const mockElement = {
+      select: vi.fn()
+    };
+
+    const aas = new AnimationActionSettings();
+    aas.t = mockTarget;
+
+    const actual = aas.getAnimatedElements(mockElement);
+    expect(mockElement.select).not.toHaveBeenCalled();
+    expect(actual[0]).toBe(mockTarget);
+  })
+});


### PR DESCRIPTION
As was mentioned in the TS comments, using a String as animation target can't be type-safe.

It is however useful to be able to animate multiple elements as one single animation, so we have modified the selection logic to allow passing a reference directly for the animation.
```javascript
// before (untyped)
actions: [
  { t: 'SomeUnsafeTarget', ...}
]
// after
actions: [
  { t: this.tag('SomeTypeSafeTarget'), ...}
]
```