### PR TITLE
Fix: ImageWorker can't load relative URLs

### DIFF
--- a/src/platforms/browser/WebPlatform.mjs
+++ b/src/platforms/browser/WebPlatform.mjs
@@ -290,6 +290,9 @@ export default class WebPlatform {
             }
         } else if (this._imageWorker) {
             // WPE-specific image parser.
+            if (typeof src !== 'string' || src.indexOf('://') < 0) {
+                return cb("Invalid image URL");
+            }
             const image = this._imageWorker.create(src);
             image.onError = function (err) {
                 return cb("Image load error");


### PR DESCRIPTION
> Relative URLs in Web Workers
> Web Workers run in a separate thread from the main JavaScript execution context. Because of this, they do not have direct access to the DOM, including the BASE tag or the document's URL. This affects how relative URLs are resolved.

Failure to provide a full URL will cause a global `SyntaxError` error to be raised, which won't result in a texture error.