### PR TITLE
Image URL validation fix for image worker

### DIFF
--- a/src/platforms/browser/WebPlatform.mjs
+++ b/src/platforms/browser/WebPlatform.mjs
@@ -290,10 +290,16 @@ export default class WebPlatform {
             }
         } else if (this._imageWorker) {
             // WPE-specific image parser.
-            // image urls can be like "//example.com/image.png"
-            if (typeof src !== 'string' || (src.indexOf('://') < 0 && !src.startsWith('//'))){
+            if (typeof src !== 'string') {
                 return cb("Invalid image URL");
             }
+            
+            // URL can start with http://, https://, and //
+            const separatorPos = src.indexOf('//');
+            if (separatorPos !== 0 && separatorPos !== 5 && separatorPos !== 6) {
+                return cb("Invalid image URL");
+            }
+
             const image = this._imageWorker.create(src);
             image.onError = function (err) {
                 return cb("Image load error");

--- a/src/platforms/browser/WebPlatform.mjs
+++ b/src/platforms/browser/WebPlatform.mjs
@@ -290,7 +290,8 @@ export default class WebPlatform {
             }
         } else if (this._imageWorker) {
             // WPE-specific image parser.
-            if (typeof src !== 'string' || src.indexOf('://') < 0) {
+            // image urls can be like "//example.com/image.png"
+            if (typeof src !== 'string' || (src.indexOf('://') < 0 && !src.startsWith('//')))
                 return cb("Invalid image URL");
             }
             const image = this._imageWorker.create(src);

--- a/src/platforms/browser/WebPlatform.mjs
+++ b/src/platforms/browser/WebPlatform.mjs
@@ -291,7 +291,7 @@ export default class WebPlatform {
         } else if (this._imageWorker) {
             // WPE-specific image parser.
             // image urls can be like "//example.com/image.png"
-            if (typeof src !== 'string' || (src.indexOf('://') < 0 && !src.startsWith('//')))
+            if (typeof src !== 'string' || (src.indexOf('://') < 0 && !src.startsWith('//'))){
                 return cb("Invalid image URL");
             }
             const image = this._imageWorker.create(src);


### PR DESCRIPTION
In some apps, image URLs are generated like this:

```js
export const getImgUrl = (imgPath, width = 185)=> {
    return `//image.example.org/t/p/w${width}${imgPath}`
};
```

So we should not expect `://` to be present in all image URLs.