### PR TITLE
Fix playwright tests

### DIFF
--- a/tests/event-emitter/test.event-emitter.js
+++ b/tests/event-emitter/test.event-emitter.js
@@ -17,8 +17,6 @@
  * limitations under the License.
  */
 
-import lng from '../../src'
-
 describe('Event Emitter', function() {
     let TestObj;
   

--- a/tests/keyhandler/test.keyhandleLong.js
+++ b/tests/keyhandler/test.keyhandleLong.js
@@ -17,8 +17,6 @@
  * limitations under the License.
  */
 
-import lng from '../../src'
-
 describe('Longpress handling', function() {
     this.timeout(0);
     let app;

--- a/tests/keyhandler/test.keyhandler.js
+++ b/tests/keyhandler/test.keyhandler.js
@@ -17,8 +17,6 @@
  * limitations under the License.
  */
 
-import lng from '../../src'
-
 describe('Key handling', function() {
     this.timeout(0);
     let app;

--- a/tests/layout/test.misc.js
+++ b/tests/layout/test.misc.js
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-import lng from '../../src'
 import FlexTestUtils from "./src/FlexTestUtils.mjs";
 
 const flexTestUtils = new FlexTestUtils();

--- a/tests/shaders/test.grayscale.js
+++ b/tests/shaders/test.grayscale.js
@@ -17,8 +17,6 @@
  * limitations under the License.
  */
 
-import lng from '../../src'
-
 describe('Shaders', function() {
     this.timeout(0);
 

--- a/tests/test.html
+++ b/tests/test.html
@@ -32,6 +32,7 @@
 
 <script>mocha.setup('bdd')</script>
 
+<script src="../dist/lightning.es5.js"></script>
 <script src="textures/test.textures.js" type="module"></script>
 <script src="textures/test.text.js" type="module"></script>
 <script src="keyhandler/test.keyhandler.js" type="module"></script>

--- a/tests/textures/test.text.js
+++ b/tests/textures/test.text.js
@@ -17,8 +17,6 @@
  * limitations under the License.
  */
 
-import lng from '../../src'
-
 const EXAMPLE_TEXT =
 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin nibh augue, \
 suscipit a, scelerisque sed, lacinia in, mi. Cras vel lorem. Etiam pellentesque \

--- a/tests/textures/test.textures.js
+++ b/tests/textures/test.textures.js
@@ -17,8 +17,6 @@
  * limitations under the License.
  */
 
-import lng from '../../src'
-
 describe('textures', function() {
     this.timeout(0);
 


### PR DESCRIPTION
The idea to have `import lng from '../../src'` was clever but it was unfortunately wrong:
- this import is NOT valid in HTML; we can only import specific files,
- this import is NOT valid for TypeScript; our index and a few files in the library are `.ts` / `.mts`.

Some tests can remain as direct imports inside `src`, while the files are `.mjs`, but most tests that need the `lng` export must use the ES5 build.
