### PR TITLE
Fix ES5 package

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "./inspector": {
       "types": "./devtools/lightning-inspect.d.ts",
       "import": "./devtools/lightning-inspect.js",
-      "require": "./devtools/lightning-inspect.js"
+      "require": "./devtools/lightning-inspect.es5.js"
     },
     "./package.json": "./package.json"
   },

--- a/vite.config.js
+++ b/vite.config.js
@@ -13,7 +13,7 @@ const isMinifiedBuild = process.env.BUILD_MINIFY === 'true';
 const isInspectorBuild = process.env.BUILD_INSPECTOR === 'true';
 
 let outDir = 'dist';
-let entry = resolve(__dirname, 'src/lightning.mjs');
+let entry = resolve(__dirname, 'src/index.ts');
 let outputBase = 'lightning';
 let sourcemap = true;
 let useDts = true;


### PR DESCRIPTION
Fix npm package is inconsistent between ESM and ES5:

- `dist/lightning.*` was bundling `src/lightning.mjs` instead of `src/index.ts`, which means it was missing some of the exports. This change increases the `min.js` file by about 2Kb.
- require `devtools` was not pointing to the ES5 version which is produced using Vite.
