### PR TITLE
Fix advanced renderer text alignment mirroring

### DIFF
--- a/src/textures/TextTextureRendererAdvanced.mjs
+++ b/src/textures/TextTextureRendererAdvanced.mjs
@@ -108,6 +108,12 @@ export default class TextTextureRendererAdvanced {
         // Set font properties.
         renderInfo.baseFont = this.setFontProperties();
 
+        let textAlign = this._settings.textAlign;
+        if (this._settings.rtl) {
+            if (!textAlign || textAlign === 'left') textAlign = 'right';
+            else if (textAlign === 'right') textAlign = 'left';
+        }
+
         renderInfo.w = w;
         renderInfo.width = w;
         renderInfo.text = this._settings.text;
@@ -116,7 +122,7 @@ export default class TextTextureRendererAdvanced {
         renderInfo.fontBaselineRatio = this._settings.fontBaselineRatio;
         renderInfo.lineHeight = lineHeight;
         renderInfo.letterSpacing = letterSpacing;
-        renderInfo.textAlign = this._settings.textAlign;
+        renderInfo.textAlign = textAlign;
         renderInfo.textColor = this._settings.textColor;
         renderInfo.verticalAlign = this._settings.verticalAlign;
         renderInfo.highlight = this._settings.highlight;

--- a/tests/rtl/test.rtl.js
+++ b/tests/rtl/test.rtl.js
@@ -343,10 +343,21 @@ describe("Right-to-Left layout", function () {
             textColor: 0xff000000,
           },
         },
+        LabelAdvanced: {
+          y: 40,
+          w: 600, // text should be visually aligned to the right at the end of the blue box
+          text: {
+            advancedRenderer: true,
+            text: "<b>Dynamic</b> attachment",
+            fontSize: 40,
+            textColor: 0xff000000,
+          },
+        },
       });
-
+      
       // before attachment to the app (and stage), the texture doesn't have the RTL flag (like its parent)
       chai.assert(!parent.tag("Label").texture.source.lookupId.includes("|rtl"));
+      chai.assert(!parent.tag("LabelAdvanced").texture.source.lookupId.includes("|rtl"));
 
       app.childList.add(parent);
       stage.drawFrame();


### PR DESCRIPTION
Until the text renderers are replaced: mirror alignment in advanced text renderer.

<img width="430" alt="image" src="https://github.com/user-attachments/assets/71196884-cf3b-40c1-9200-26981ab52021" />
