### PR TITLE
Feature: expose lines layout in renderInfo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": "Metrological, Bas van Meurs <b.van.meurs@metrological.com>",
   "name": "@lightningjs/core",
-  "version": "2.16.0-beta.1",
+  "version": "2.16.0-beta.3",
   "license": "Apache-2.0",
   "type": "module",
   "types": "dist/src/index.d.ts",

--- a/src/textures/TextTextureRendererTypes.ts
+++ b/src/textures/TextTextureRendererTypes.ts
@@ -69,7 +69,7 @@ export interface ILineInfo {
  * Complete text layout information
  */
 export interface IRenderInfo {
-  lines: ILineInfo[];
+  lines: IDrawLineInfo[];
   remainingText: string;
   moreTextLines: boolean;
   precision: number;


### PR DESCRIPTION
Improve text renderer's `renderInfo` to return the full lines layout (each line's x and y). The lines layout is just moved into `_calculateRenderInfo` instead of being calculated in the `_draw` method.

This is necessary, when implementing bidirectional (LTR / RTL) text input, to correctly calculate the caret.