### PR TITLE
Fix: ZWSP regex bug fix

### DIFF
--- a/src/textures/bidiTokenizer.ts
+++ b/src/textures/bidiTokenizer.ts
@@ -23,8 +23,8 @@ import type { DirectedSpan } from "./TextTextureRendererAdvancedUtils.js";
 let bidi: BidiAPI;
 
 // https://www.unicode.org/reports/tr9/
-const reZeroWidthSpace = /[\u200B\u200E\u200F\u061C]/g;
-const reDirectionalFormat = /[\u202A\u202B\u202C\u202D\u202E\u202E\u2066\u2067\u2068\u2069]/g;
+const reZeroWidthSpace = /[\u200B\u200E\u200F\u061C]/;
+const reDirectionalFormat = /[\u202A\u202B\u202C\u202D\u202E\u202E\u2066\u2067\u2068\u2069]/;
 
 const reQuoteStart = /^["“”«»]/;
 const reQuoteEnd = /["“”«»]$/;


### PR DESCRIPTION
Why Javascript? Why?
```typescript
const reZWSP = /[\u200B]/;
console.log(1, reZWSP.test('\u200B')); // 1, true
console.log(2, reZWSP.test('\u200B')); // 2, true

const reZWSPGlobal = /[\u200B]/g;
console.log(1, reZWSPGlobal.test('\u200B')); // 1, true
console.log(2, reZWSPGlobal.test('\u200B')); // 2, false
```