### PR TITLE
Fix: occasional incorrect tree order in `getChildrenAtPosition`

### DIFF
--- a/src/tree/Stage.mjs
+++ b/src/tree/Stage.mjs
@@ -22,6 +22,7 @@
  */
 
 import EventEmitter from "../EventEmitter.mjs";
+import ElementCore from "./core/ElementCore.mjs";
 import Utils from "./Utils.mjs";
 import WebGLRenderer from "../renderer/webgl/WebGLRenderer.mjs";
 import C2dRenderer from "../renderer/c2d/C2dRenderer.mjs";
@@ -543,9 +544,11 @@ export default class Stage extends EventEmitter {
 
     getChildrenByPosition(x, y) {
         const children = [];
-        this.root.core.update();
+        this.ctx.updateTreeOrder = 0;
+        this.root.core.updateTreeOrder();
         this.root.core.collectAtCoord(x, y, children);
 
+        children.sort(ElementCore.sortZIndexedChildren);
         return children;
     }
 }

--- a/src/tree/core/CoreContext.d.mts
+++ b/src/tree/core/CoreContext.d.mts
@@ -25,6 +25,7 @@ export default class CoreContext {
   stage: Stage;
 
   renderToTextureCount: number;
+  updateTreeOrder: number;
 
   constructor(stage: Stage);
 

--- a/src/tree/core/ElementCore.d.mts
+++ b/src/tree/core/ElementCore.d.mts
@@ -121,6 +121,8 @@ declare class ElementCore {
   /**
    * Fill the array `children` with all the ElementCore instances (including itself and
    * its children) that intersect the point (`x`, `y`)
+   * 
+   * To enforce z-sorting, the result should be sorted using `ElementCore.sortZIndexedChildren`.
    *
    * @param x
    * @param y

--- a/src/tree/core/ElementCore.mjs
+++ b/src/tree/core/ElementCore.mjs
@@ -2032,8 +2032,8 @@ export default class ElementCore {
                 }
             } else {
                 a.splice(n); // Remove items that were sorted in b array, so that we can sort a
-+               // Beware that the function passed here to Array.sort must be stable
-+               a.sort(ElementCore.sortZIndexedChildren); // Needed because items with same _zIndex may not be ordered by _updateTreeOrder
+                // Beware that the function passed here to Array.sort must be stable
+                a.sort(ElementCore.sortZIndexedChildren); // Needed because items with same _zIndex may not be ordered by _updateTreeOrder
                 // Merge-sort arrays;
                 ptr = 0;
                 let i = 0;
@@ -2163,8 +2163,6 @@ export default class ElementCore {
                 this._children[i].collectAtCoord(x, y, children);
             }
         }
-
-        return children.sort(ElementCore.sortZIndexedChildren);
     }
 
     inBound(tx, ty) {


### PR DESCRIPTION
Fixes #554 - getChildrenByPosition wrong order
Might fix #129 - zIndexedChildren order obsolete when out of bounds

## Issue

`Stage.getChildrenByPosition(x, y)` collects elements at the (global) `x, y` location, internally calling `ElementCore.collectAtCoord(x, y, children)`

```javascript
    getChildrenByPosition(x, y) {
        // collector target
        const children = [];

        // force updating from the root
        this.root.core.update();

        // collect children recursively
        this.root.core.collectAtCoord(x, y, children);

        return children;
    }
```

Internally, `collectAtCoord` sorts the result using `ElementCore.sortZIndexedChildren`. The issue with this sorting function is that it doesn't just sort by `zIndex`, but also by `core._updateTreeOrder`, but this value can be wrong.

One may think that `this.root.core.update()` would ensure the tree order is correct, but this is wrong: tree ordering depends on `ctx.updateTreeOrder` to be reset before running the update.

The result is randomly wrong elements ordering:
- tree order is updated following some (slightly confusing) heuristics, so it only happens occasionally,
- when this happens it increments based on `ctx.updateTreeOrder`,
- consequently, when `Stage` calls `root.core.update()`, some parts of the tree may be ordered based on the current (non reinitialised) value of `ctx.updateTreeOrder`, resulting in some subtree having randomly a "high" tree order value, meaning these elements will appear to be on top during in the resulting `collectAtCoord`.

## Solution

`Stage` should only request a tree order update, ensuring `ctx.updateTreeOrder` is properly reset.

Additionally, `collectAtCoord` quite inefficiently re-sorts the children on every iteration, so it's better to only sort at the very end.

## Testing

This issue was happening in our (large and complex) Lightning application in a fairly consistent way (but very hard to extract in a sample).

We did work around it by doing a brute-force updating of all the elements' tree order before calling `root.collectAtCoord` directly. Now this PR attempts at fixing the root cause properly and for all Lightning users.

We could confirm this finer fix allowed us to remove our workaround without causing regressions. However we don't use any `zIndex` so can't verify this use case.