### PR TITLE
Add direction detection and isolates

### DIFF
--- a/src/textures/bidi.d.mts
+++ b/src/textures/bidi.d.mts
@@ -3,7 +3,13 @@
  */
 declare module "bidi-js" {
   export interface BidiAPI {
-    getEmbeddingLevels(text: string): { levels: number[] };
+    getEmbeddingLevels(
+      text: string,
+      baseDirection?: "ltr" | "rtl" | "auto"
+    ): {
+      levels: number[];
+    };
+    getBidiCharTypeName(c: string): "L" | "R" | "AL" | "EN" | "ES" | "CS" | "ON" | "NSM" | "BN" | "B" | "S" | "WS" | "PDF" | "LRE" | "RLE" | "LRO" | "RLO";
   }
 
   declare function bidiFactory(): BidiAPI;

--- a/tests/text-rendering.html
+++ b/tests/text-rendering.html
@@ -32,6 +32,10 @@
     h2 {
       background-color: lightgray;
     }
+    h2 small {
+      font-size: 30px;
+      font-weight: normal;
+    }
     p {
       margin: 0;
       display: -webkit-box;


### PR DESCRIPTION
## Implementation gaps

The initial implementation of bidirectional text rendering suffers from gaps:

- Generally we aim to follow HTML `auto` behavior,
- However we don't handle “weakly directional” text, e.g. `5 {RTL minutes}` will be considered LTR primary (`5`) followed by RTL text, while `5` is weak and it should inherit the RTL direction,
- We don't support “isolates”, e.g. control characters (`LFI` - left isolate, `RLI` - right isolate, `FSI` - auto isolate, `PDI` - pop isolate) which should be usable to control the direction of the rendering for spans of text. 

The last point is important to correctly render mixed LTR/RTL text, where you want to ensure one general layout (for instance wrapping with a `RLI` isolate) but concatenating labels which could be English or RTL (for instance an English title followed by a RTL description).

## New tests to demonstrate detection and isolates

First 2 show that despite starting with a number (weak LTR) the whole text is considered RTL.

3rd test shows that you can render with a general forced RTL direction a series of isolated labels with direction auto-detected ("90 minutes" in English followed by "90 minutes" in Hebrew).

<img width="553" height="765" alt="image" src="https://github.com/user-attachments/assets/74b2fe58-79b3-4d7f-a562-302454c54f87" />


