### PR TITLE
Fix/image data url 575

### DIFF
--- a/src/platforms/browser/WebPlatform.mjs
+++ b/src/platforms/browser/WebPlatform.mjs
@@ -295,8 +295,9 @@ export default class WebPlatform {
             }
             
             // URL can start with http://, https://, and //
+            // (Ignore data URLs that start with data:)
             const separatorPos = src.indexOf('//');
-            if (separatorPos !== 0 && separatorPos !== 5 && separatorPos !== 6) {
+            if (!src.startsWith('data:') && separatorPos !== 0 && separatorPos !== 5 && separatorPos !== 6) {
                 return cb("Invalid image URL");
             }
 

--- a/src/platforms/browser/WebPlatform.test.mjs
+++ b/src/platforms/browser/WebPlatform.test.mjs
@@ -180,6 +180,33 @@ describe('WebPlatform', () => {
             expect(mockImage.cancel).toHaveBeenCalledTimes(1);
         });
 
+        it('loads data URLs', () => {
+            const mockImage = {
+                cancel: vi.fn()
+            };
+
+            webPlatform._imageWorker = {
+                create: vi.fn().mockReturnValue(mockImage)
+            };
+            
+            const opts = {
+                src: 'data:image/png;base64;1234567890ABCDEFcoolPNGdude'
+            }
+
+            const cancelCb = webPlatform.loadSrcTexture(opts, () => {
+                throw 'Should not happen'
+            });
+
+            expect(webPlatform._imageWorker.create).toHaveBeenCalledWith(opts.src);
+            expect(typeof mockImage.onLoad).toBe('function');
+            expect(typeof mockImage.onError).toBe('function');
+            expect(mockImage.cancel).toHaveBeenCalledTimes(0);
+
+            cancelCb();
+
+            expect(mockImage.cancel).toHaveBeenCalledTimes(1);
+        });
+
         it('fails with relative URLs', () => {
             const mockImage = {
                 cancel: vi.fn()


### PR DESCRIPTION
Fixes #575 

A change that was added to check Image src urls caused a regression when using image data urls - this has broken our app as we use this feature to display QR codes generated on the fly.

This fix preserves the original check but ignores these checks for data urls (that begin with `data:`.

This has broken our My Sky app and we have had to revert to an older version of Lightning core until this is released.