### PR TITLE
Fix idling

### DIFF
--- a/src/tree/Stage.d.mts
+++ b/src/tree/Stage.d.mts
@@ -427,7 +427,7 @@ declare class Stage extends EventEmitter<Stage.EventMap> {
    */
   isUpdatingFrame(): boolean;
 
-  // renderFrame(): void;
+  // renderFrame(): boolean;
   // - Only used internally
 
   /**

--- a/src/tree/Stage.mjs
+++ b/src/tree/Stage.mjs
@@ -170,7 +170,7 @@ export default class Stage extends EventEmitter {
     _setOptions(o) {
         this._options = {};
 
-        let opt = (name, def) => {
+        const opt = (name, def) => {
             let value = o[name];
 
             if (value === undefined) {
@@ -315,7 +315,7 @@ export default class Stage extends EventEmitter {
             this._updateSourceTextures.forEach(texture => {
                 texture._performUpdateSource();
             });
-            this._updateSourceTextures = new Set();
+            this._updateSourceTextures.clear();
         }
     }
 
@@ -335,12 +335,6 @@ export default class Stage extends EventEmitter {
         this.emit('frameStart');
         this._performUpdateSource();
         this.emit('update');
-    }
-
-    idleFrame() {
-        this.textureThrottler.processSome();
-        this.emit('frameEnd');
-        this.frameCounter++;
     }
 
     onIdle() {
@@ -366,6 +360,8 @@ export default class Stage extends EventEmitter {
         this.emit('frameEnd');
 
         this.frameCounter++;
+
+        return changes;
     }
 
     isUpdatingFrame() {


### PR DESCRIPTION
`pauseRafOnIdle` code was in need of a cleanup, and `onIdle` was firing during the 1st normal RAF

- minor refactoring
- reduced the idle loop to target 30fps instead of 60
- reduced switching to idle loop to 30 RAF frames (~500ms) instead of 60 (~1s)
- emit `onIdle` only when we switch to the idle loop