### PR TITLE
Fix DOM Inspector flex-box support

### DIFF
--- a/devtools/lightning-inspect.js
+++ b/devtools/lightning-inspect.js
@@ -160,7 +160,9 @@ window.attachInspector = function({Application, Element, ElementCore, Stage, Com
                                 if (!f[3]) c["colorBr"] = pv;
                                 break;
                             default:
-                                c[rn] = pv;
+                                if (c[rn] !== pv) { // prevent infinite update loop
+                                    c[rn] = pv;
+                                }
                         }
 
                         // Set final value, not the transitioned value.
@@ -352,7 +354,11 @@ window.attachInspector = function({Application, Element, ElementCore, Stage, Com
         },
         set: function(v) {
             if (this.$x !== v) {
-                val(this, 'x', v, 0);
+                if (this.hasFlexLayout()) {
+                    val(this, 'x', this.layout.originalX, 0); // show non computed value
+                } else {
+                    val(this, 'x', v, 0);
+                }
                 this.$x = v;
                 this.updateLeft();
             }
@@ -366,7 +372,11 @@ window.attachInspector = function({Application, Element, ElementCore, Stage, Com
         },
         set: function(v) {
             if (this.$y !== v) {
-                val(this, 'y', v, 0);
+                if (this.hasFlexLayout()) {
+                    val(this, 'y', this.layout.originalY, 0); // show non computed value
+                } else {
+                    val(this, 'y', v, 0);
+                }
                 this.$y = v;
                 this.updateTop();
             }

--- a/src/tree/core/ElementCore.mjs
+++ b/src/tree/core/ElementCore.mjs
@@ -201,8 +201,9 @@ export default class ElementCore {
         } else {
             this._disableFuncX();
             if (this.hasFlexLayout()) {
-                this.x += (v - this._layout.originalX);
+                const dx = v - this._layout.originalX;
                 this._layout.setOriginalXWithoutUpdatingLayout(v);
+                this.x += dx;
             } else {
                 this.x = v;
             }
@@ -261,8 +262,9 @@ export default class ElementCore {
         } else {
             this._disableFuncY();
             if (this.hasFlexLayout()) {
-                this.y += (v - this._layout.originalY);
+                const dy = v - this._layout.originalY;
                 this._layout.setOriginalYWithoutUpdatingLayout(v);
+                this.y += dy;
             } else {
                 this.y = v;
             }


### PR DESCRIPTION
DOM inspector was ambiguously displaying flex-computed x/y coordinates, and editing those coordinates would cause an infinite update loop.

- DOM displays original x/y coordinates instead of computed values
- Editing x/y updates the element's original x/y which is used as offset in the flex-box calculations