### PR TITLE
Font accuracy fix

### DIFF
--- a/src/textures/TextTextureRendererAdvancedUtils.ts
+++ b/src/textures/TextTextureRendererAdvancedUtils.ts
@@ -359,7 +359,7 @@ export function layoutSpans(
           const reversed = primaryRtl !== rtl;
           do {
             text = reversed ? trimWordStart(text, rtl) : trimWordEnd(text, rtl);
-            width = ctx.measureText(text).width;
+            width = measureText(ctx, text, letterSpacing);
           } while (width > maxWidth);
           if (width > suffixWidth) {
             last = {

--- a/tests/text-rendering.html
+++ b/tests/text-rendering.html
@@ -19,14 +19,19 @@
 
 <!DOCTYPE html>
 <html>
+  <head>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;700&family=Noto+Sans+Arabic:wght@400;700&family=Noto+Sans+Hebrew:wght@400;700&display=swap" rel="stylesheet">
+  </head>
   <style>
     body {
       overflow: hidden;
       background: white;
     }
     * {
-      font-size: 40px;
-      font-family: Arial;
+      font-size: 36px;
+      font-family: "Noto Sans", "Noto Sans Arabic", "Noto Sans Hebrew", sans-serif;
       line-height: 48px;
     }
     h2 {

--- a/tests/text-rendering.spec.ts
+++ b/tests/text-rendering.spec.ts
@@ -33,6 +33,9 @@ const COMPLEX_HEBREW_COUNT = 2;
 const COMPLEX_ARABIC = COMPLEX_HEBREW + COMPLEX_HEBREW_COUNT;
 const COMPLEX_ARABIC_COUNT = 1;
 
+const BASIC_MAX_DIFF = 50;
+const LOOSE_MAX_DIFF = 75;
+
 const OUTPUT_DIR = "temp/playwright";
 
 async function compareWrapping(page: Page, width: number) {
@@ -63,9 +66,8 @@ async function compareWrapping(page: Page, width: number) {
         `Test ${i} - ${width}px - different pixels: ${differentPixels}`
       );
     }
-    const maxDiff = i >= BIDI_TESTS ? 150 : 50; // Arabic needs more tolerance
     expect(
-      equal || differentPixels < maxDiff,
+      equal || differentPixels < BASIC_MAX_DIFF,
       `[Test ${i}] HTML and canvas rendering do not match (${differentPixels} pixels differ)`
     ).toBe(true);
   }
@@ -100,7 +102,7 @@ async function compareLetterSpacing(page: Page, width: number) {
       );
     }
     expect(
-      equal || differentPixels < 50,
+      equal || differentPixels < LOOSE_MAX_DIFF,
       `[Test ${i}] HTML and canvas rendering do not match (${differentPixels} pixels differ)`
     ).toBe(true);
   }
@@ -134,13 +136,13 @@ async function compareDetection(page: Page, width: number, start: number, count:
       );
     }
     expect(
-      equal || differentPixels < 50,
+      equal || differentPixels < BASIC_MAX_DIFF,
       `[Test ${i}] HTML and canvas rendering do not match (${differentPixels} pixels differ)`
     ).toBe(true);
   }
 }
 
-async function compareComplex(page: Page, width: number, start: number, count: number, maxDiff = 100) {
+async function compareComplex(page: Page, width: number, start: number, count: number) {
   await page.setViewportSize({ width, height: 4000 });
   await page.goto("/tests/text-rendering.html?playwright");
 
@@ -168,7 +170,7 @@ async function compareComplex(page: Page, width: number, start: number, count: n
       );
     }
     expect(
-      equal || differentPixels < maxDiff,
+      equal || differentPixels < BASIC_MAX_DIFF,
       `[Test ${i}] HTML and canvas rendering do not match (${differentPixels} pixels differ)`
     ).toBe(true);
   }
@@ -195,12 +197,8 @@ test("wrap 840", async ({ page }) => {
   await compareWrapping(page, 840);
 });
 
-test("wrap 720", async ({ page }) => {
-  await compareWrapping(page, 720);
-});
-
-test("wrap 630", async ({ page }) => {
-  await compareWrapping(page, 630);
+test("wrap 700", async ({ page }) => {
+  await compareWrapping(page, 700);
 });
 
 // TODO: fix embedded RTL in LTR
@@ -208,12 +206,12 @@ test("wrap 630", async ({ page }) => {
 //   await compareWrapping(page, 510);
 // });
 
-test("letter spacing 1", async ({ page }) => {
+test("letter spacing wrap 1000", async ({ page }) => {
   await compareLetterSpacing(page, 1000);
 });
 
-test("letter spacing 2", async ({ page }) => {
-  await compareLetterSpacing(page, 550);
+test("letter spacing wrap 600", async ({ page }) => {
+  await compareLetterSpacing(page, 600);
 });
 
 test("direction detection", async ({ page }) => {
@@ -229,5 +227,5 @@ test("complex Hebrew 880", async ({ page }) => {
 });
 
 test("complex Arabic 900", async ({ page }) => {
-  await compareComplex(page, 900, COMPLEX_ARABIC, COMPLEX_ARABIC_COUNT, 300);
+  await compareComplex(page, 900, COMPLEX_ARABIC, COMPLEX_ARABIC_COUNT);
 });

--- a/tests/text-rendering/index.js
+++ b/tests/text-rendering/index.js
@@ -300,9 +300,9 @@ function getDefaultSettings() {
     textColor: 0xff000000,
     textBaseline: "alphabetic",
     verticalAlign: "top",
-    fontFace: null,
+    fontFace: ["Noto Sans", "Noto Sans Arabic", "Noto Sans Hebrew"],
     fontStyle: "",
-    fontSize: 40,
+    fontSize: 36,
     lineHeight: 48,
     wordWrap: true,
     letterSpacing,
@@ -315,9 +315,9 @@ function getDefaultSettings() {
     paddingRight: 0,
     offsetY: null,
     cutSx: 0,
-    cutSy: 0,
     cutEx: 0,
-    cutEy: 0,
+    cutSy: -3, // adjust vertical rendering to match HTML
+    cutEy: 999,
     w: 0,
     h: 0,
     highlight: false,
@@ -388,4 +388,21 @@ document.addEventListener("wheel", (e) => {
   location.hash = `#test${scrollN}`;
 });
 
-demo();
+// Wait for Noto Sans fonts to load before running demo
+document.fonts.ready.then(() => {
+  // Explicitly load Noto Sans families in regular and bold weights
+  Promise.all([
+    document.fonts.load('400 36px "Noto Sans"'),
+    document.fonts.load('700 36px "Noto Sans"'),
+    document.fonts.load('400 36px "Noto Sans Arabic"'),
+    document.fonts.load('700 36px "Noto Sans Arabic"'),
+    document.fonts.load('400 36px "Noto Sans Hebrew"'),
+    document.fonts.load('700 36px "Noto Sans Hebrew"')
+  ]).then(() => {
+    demo();
+  }).catch((error) => {
+    console.error('Font loading failed:', error);
+    // Run demo anyway
+    demo();
+  });
+});


### PR DESCRIPTION
We found in CI that Playwright would run a browser with very different "Arial" font.

Solution chosen is to load Noto:

- The web font should render very similarly on all systems,
- Added bonus is that Noto Arabic has a much cleaner shape allowing to decrease the render comparison accuracy

While changing the font and adjusting the playwright test cases, I found a bug in the ellipsis logic with non-zero letter-spacing - so that's fixed as well!

<img width="850" height="798" alt="image" src="https://github.com/user-attachments/assets/dad0e2fc-8b95-4966-8487-181ee90ff215" />
