### PR TITLE
Fix `freeTextureSource()` leaving stale entries in `textureSourceHashmap`

### DIFF
--- a/src/tree/TextureManager.mjs
+++ b/src/tree/TextureManager.mjs
@@ -53,7 +53,7 @@ export default class TextureManager {
         for (let i = 0, n = this._uploadedTextureSources.length; i < n; i++) {
             this._nativeFreeTextureSource(this._uploadedTextureSources[i]);
         }
-        
+
         this.textureSourceHashmap.clear();
         this._usedMemory = 0;
     }
@@ -95,7 +95,7 @@ export default class TextureManager {
         nativeTexture.update = this.stage.frameCounter;
 
         this._uploadedTextureSources.push(textureSource);
-        
+
         this.addToLookupMap(textureSource);
 
         // add VRAM tracking if using the webgl renderer
@@ -140,7 +140,7 @@ export default class TextureManager {
     gc() {
         this.freeUnusedTextureSources();
     }
-    
+
     freeUnusedTextureSources() {
         let remainingTextureSources = [];
         for (let i = 0, n = this._uploadedTextureSources.length; i < n; i++) {
@@ -194,6 +194,8 @@ export default class TextureManager {
             }
             this._nativeFreeTextureSource(textureSource);
         }
+
+        this.textureSourceHashmap.delete(textureSource.lookupId);
 
         // Should be reloaded.
         textureSource.loadingSince = null;

--- a/src/tree/TextureManager.mjs
+++ b/src/tree/TextureManager.mjs
@@ -190,6 +190,7 @@ export default class TextureManager {
         if (textureSource.isLoaded()) {
             if (managed) {
                 this._addMemoryUsage(-textureSource.w * textureSource.h);
+                this._updateVramUsage(textureSource, -1);
                 this._uploadedTextureSources.splice(index, 1);
             }
             this._nativeFreeTextureSource(textureSource);


### PR DESCRIPTION
When `gc()` is called, it calls `freeUnusedTextureSources`, which at the end calls `_cleanupLookupMap`, cleaning up all unused texture sources from `textureSourceHashmap`.

However, when `freeTextureSource` is called (either when a texture source is replaced or when someone manually calls `texture.free()`), the stale texture source is kept inside `textureSourceHashmap`, leading to a memory leak.

This issue was detected because we use a single text texture for subtitles, and keep changing the text of that texture as playback progresses.